### PR TITLE
DevideSDK{Android,Generic}: DeviceSDK is an api dependency

### DIFF
--- a/DeviceSDKAndroid/build.gradle
+++ b/DeviceSDKAndroid/build.gradle
@@ -43,7 +43,7 @@ android {
 	}
 
 	dependencies {
-		implementation project(':DeviceSDK')
+		api project(':DeviceSDK')
 
 		implementation 'org.eclipse.paho:org.eclipse.paho.android.service:1.1.1'
 

--- a/DeviceSDKGeneric/build.gradle
+++ b/DeviceSDKGeneric/build.gradle
@@ -15,7 +15,7 @@ configurations {
 }
 
 dependencies {
-	implementation project(':DeviceSDK')
+	api project(':DeviceSDK')
 
 	implementation 'com.j256.ormlite:ormlite-core:5.1'
 	api 'com.j256.ormlite:ormlite-jdbc:5.1'


### PR DESCRIPTION
Users must be able to access common DeviceSDK classes too

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>