### PR TITLE
Fix failed message persistency

### DIFF
--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterfaceMappingNotFoundException.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterfaceMappingNotFoundException.java
@@ -1,6 +1,6 @@
 package org.astarteplatform.devicesdk.protocol;
 
-class AstarteInterfaceMappingNotFoundException extends Exception {
+public class AstarteInterfaceMappingNotFoundException extends Exception {
   public AstarteInterfaceMappingNotFoundException(String message) {
     super(message);
   }

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1Transport.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1Transport.java
@@ -12,7 +12,6 @@ import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_WRITE_TIM
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -60,7 +59,6 @@ import org.joda.time.DateTime;
 
 public class AstarteMqttV1Transport extends AstarteMqttTransport {
   private final String m_baseTopic;
-  private ArrayDeque<AstarteFailedMessage> mFailedMessages;
   private final BSONDecoder mBSONDecoder = new BasicBSONDecoder();
   private final BSONCallback mBSONCallback = new BasicBSONCallback();
   private final MqttCallback mMqttCallback =

--- a/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidFailedMessageStorage.java
+++ b/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidFailedMessageStorage.java
@@ -19,21 +19,21 @@ public class AstarteAndroidFailedMessageStorage implements AstarteFailedMessageS
   @Override
   public void insertVolatile(String topic, byte[] payload, int qos) {
     AstarteAndroidFailedMessage m = new AstarteAndroidFailedMessage(topic, payload, qos);
-    mFailedMessageQueue.push(m);
+    mFailedMessageQueue.add(m);
   }
 
   @Override
   public void insertVolatile(String topic, byte[] payload, int qos, int relativeExpiry) {
     AstarteAndroidFailedMessage m =
         new AstarteAndroidFailedMessage(topic, payload, qos, relativeExpiry);
-    mFailedMessageQueue.push(m);
+    mFailedMessageQueue.add(m);
   }
 
   @Override
   public void insertStored(String topic, byte[] payload, int qos) throws AstarteTransportException {
     AstarteAndroidFailedMessage m = new AstarteAndroidFailedMessage(topic, payload, qos);
     try {
-      storeAndPushMessage(m);
+      storeAndAddMessage(m);
     } catch (Exception e) {
       throw new AstarteTransportException("Cannot store failed message", e);
     }
@@ -45,16 +45,16 @@ public class AstarteAndroidFailedMessageStorage implements AstarteFailedMessageS
     AstarteAndroidFailedMessage m =
         new AstarteAndroidFailedMessage(topic, payload, qos, relativeExpiry);
     try {
-      storeAndPushMessage(m);
+      storeAndAddMessage(m);
     } catch (Exception e) {
       throw new AstarteTransportException("Cannot store failed message", e);
     }
   }
 
-  private void storeAndPushMessage(AstarteAndroidFailedMessage message) {
+  private void storeAndAddMessage(AstarteAndroidFailedMessage message) {
     long storageId = mFailedMessageDao.insert(message);
     message.setStorageId(storageId);
-    mFailedMessageQueue.push(message);
+    mFailedMessageQueue.add(message);
   }
 
   @Override


### PR DESCRIPTION
Fix a regression introduced with the failed message persistency mechanism that prevented publish on property interfaces. Also ensure the correct order of redelivery.