### PR TITLE
Fix aggregate datastream validation

### DIFF
--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDeviceAggregateDatastreamInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDeviceAggregateDatastreamInterface.java
@@ -19,7 +19,7 @@ public class AstarteDeviceAggregateDatastreamInterface extends AstarteAggregateD
   public void streamData(String path, Map<String, Object> payload, DateTime timestamp)
       throws AstarteTransportException, AstarteInvalidValueException,
           AstarteInterfaceMappingNotFoundException {
-    validateAggregate(this, payload, timestamp);
+    validateAggregate(this, path, payload, timestamp);
 
     AstarteTransport transport = getAstarteTransport();
     if (transport == null) {

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterface.java
@@ -162,23 +162,20 @@ public abstract class AstarteInterface {
   }
 
   public static void validateAggregate(
-      AstarteInterface astarteInterface, Map<String, Object> payload, DateTime timestamp)
+      AstarteInterface astarteInterface,
+      String pathPrefix,
+      Map<String, Object> payload,
+      DateTime timestamp)
       throws AstarteInvalidValueException, AstarteInterfaceMappingNotFoundException {
     // We need to ensure the path list matches
-    // TODO: Aggregate validation in Astarte is still WIP. Get back to this when it's final.
     if (astarteInterface.getMappings().size() != payload.size()) {
       throw new AstarteInterfaceMappingNotFoundException(
           "The interface mapping and the payload don't match.");
     }
     for (Map.Entry<String, Object> payloadEntry : payload.entrySet()) {
+      String path = pathPrefix + "/" + payloadEntry.getKey();
       validatePayload(
-          findMappingInInterface(astarteInterface, payloadEntry.getKey()),
-          payloadEntry.getValue(),
-          timestamp);
-    }
-    if (!astarteInterface.getMappings().keySet().equals(payload.keySet())) {
-      throw new AstarteInterfaceMappingNotFoundException(
-          "The interface mapping and the payload don't match.");
+          findMappingInInterface(astarteInterface, path), payloadEntry.getValue(), timestamp);
     }
   }
 


### PR DESCRIPTION
Join the path prefix with the payload key when looking for the mappings.
Moreover, remove the keySet check since it's currently wrong and redundant (we
already check that the payload and the mappings are the same length and then we
go through each payload key and search it, prefixed, in the mappings).

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>