### PR TITLE
AstarteGenericCryptoStore: use ECDSA for key generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-rc.0] - Unreleased
+### Changed
+- [generic] Use ECDSA instead of RSA for key generation
+
 ## [1.0.0-beta.2] - 2021-03-30
 ### Added
 - Compatibility with Android > 10

--- a/DeviceSDKGeneric/src/main/java/org/astarteplatform/devicesdk/generic/AstarteGenericCryptoStore.java
+++ b/DeviceSDKGeneric/src/main/java/org/astarteplatform/devicesdk/generic/AstarteGenericCryptoStore.java
@@ -9,8 +9,10 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.security.spec.ECGenParameterSpec;
 import javax.net.ssl.SSLSocketFactory;
 import org.astarteplatform.devicesdk.crypto.AstarteCryptoStore;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -68,8 +70,8 @@ class AstarteGenericCryptoStore implements AstarteCryptoStore {
     // Clear the KeyStore first.
     clearKeyStore();
 
-    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-    keyGen.initialize(4096);
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+    keyGen.initialize(new ECGenParameterSpec("secp256r1"), new SecureRandom());
 
     m_keyPair = keyGen.generateKeyPair();
   }
@@ -88,7 +90,7 @@ class AstarteGenericCryptoStore implements AstarteCryptoStore {
     X500Name subjectName = new X500Name(directoryString);
     JcaPKCS10CertificationRequestBuilder kpGen =
         new JcaPKCS10CertificationRequestBuilder(subjectName, m_keyPair.getPublic());
-    JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder("SHA256withRSA");
+    JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder("SHA256withECDSA");
     ContentSigner signer = csBuilder.build(m_keyPair.getPrivate());
     PKCS10CertificationRequest request = kpGen.build(signer);
 


### PR DESCRIPTION
Allow generating keys quicker on restricted hardware

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>