### PR TITLE
Avoid catching null pointer exception

### DIFF
--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
@@ -154,11 +154,13 @@ public abstract class AstartePairableDevice extends AstarteDevice
 
   @Override
   public boolean isConnected() {
-    try {
-      return mAstarteTransport.isConnected();
-    } catch (NullPointerException e) {
-      return false;
+    boolean connected;
+    if (mAstarteTransport != null) {
+      connected = mAstarteTransport.isConnected();
+    } else {
+      connected = false;
     }
+    return connected;
   }
 
   @Override


### PR DESCRIPTION
AstartePairableDevice: Remove catch of NPE. 

Signed-off-by: Antonio Gisondi <antonio.gisondi@secomind.com>