### PR TITLE
Refactor Data Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.1.0-dev] - Unreleased
+### Added
+- Sending data on an endpoint not present in interface now triggers an exception.
+- Sending an object with fewer data than needed now triggers an exception.
+- Sending a non-numeric value on an endpoint with type Double now triggers an exception.
 ### Changed
+- Data is now validated against their exact types.
 - Update Gradle to latest stable 7.2
 - [android] Update Android Gradle plugin and Android target version
 

--- a/DeviceSDK/build.gradle
+++ b/DeviceSDK/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
 	testImplementation 'junit:junit:4.13'
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
+	testImplementation "org.mockito:mockito-core:3.+"
 }
 
 ext {

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDeviceAggregateDatastreamInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDeviceAggregateDatastreamInterface.java
@@ -19,7 +19,7 @@ public class AstarteDeviceAggregateDatastreamInterface extends AstarteAggregateD
   public void streamData(String path, Map<String, Object> payload, DateTime timestamp)
       throws AstarteTransportException, AstarteInvalidValueException,
           AstarteInterfaceMappingNotFoundException {
-    validateAggregate(this, path, payload, timestamp);
+    validatePayload(path, payload, timestamp);
 
     AstarteTransport transport = getAstarteTransport();
     if (transport == null) {
@@ -27,5 +27,30 @@ public class AstarteDeviceAggregateDatastreamInterface extends AstarteAggregateD
     }
 
     transport.sendAggregate(this, path, payload, timestamp);
+  }
+
+  public void validatePayload(String path, Map<String, Object> payload, DateTime timestamp)
+      throws AstarteInvalidValueException, AstarteInterfaceMappingNotFoundException {
+    String fomattedPath = path + "/";
+    final Map<String, AstarteInterfaceMapping> mappings = getMappings();
+
+    for (Map.Entry<String, AstarteInterfaceMapping> interfaceMappingEntry : mappings.entrySet()) {
+      final AstarteInterfaceMapping astarteInterfaceMapping = interfaceMappingEntry.getValue();
+      if (!payload.containsKey(
+          astarteInterfaceMapping.getPath().substring((fomattedPath).length()))) {
+        throw new AstarteInvalidValueException(
+            String.format("Value not found for %s", astarteInterfaceMapping.getPath()));
+      }
+    }
+
+    for (Map.Entry<String, Object> data : payload.entrySet()) {
+      if (mappings.containsKey(fomattedPath + data.getKey())) {
+        findMappingInInterface(fomattedPath + data.getKey())
+            .validatePayload(data.getValue(), timestamp);
+      } else {
+        throw new AstarteInterfaceMappingNotFoundException(
+            String.format("%s not found in interface", fomattedPath + data.getKey()));
+      }
+    }
   }
 }

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDeviceDatastreamInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDeviceDatastreamInterface.java
@@ -18,7 +18,7 @@ public class AstarteDeviceDatastreamInterface extends AstarteDatastreamInterface
   public void streamData(String path, Object payload, DateTime timestamp)
       throws AstarteTransportException, AstarteInvalidValueException,
           AstarteInterfaceMappingNotFoundException {
-    validatePayload(this, path, payload, timestamp);
+    validatePayload(path, payload, timestamp);
 
     AstarteTransport transport = getAstarteTransport();
     if (transport == null) {

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDevicePropertyInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDevicePropertyInterface.java
@@ -15,7 +15,7 @@ public class AstarteDevicePropertyInterface extends AstartePropertyInterface
   public void setProperty(String path, Object payload)
       throws AstarteTransportException, AstarteInvalidValueException,
           AstarteInterfaceMappingNotFoundException {
-    validatePayload(this, path, payload, null);
+    validatePayload(path, payload, null);
 
     AstarteTransport transport = getAstarteTransport();
     if (transport == null) {

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterface.java
@@ -104,79 +104,22 @@ public abstract class AstarteInterface {
     return astarteInterface;
   }
 
-  public static AstarteInterfaceMapping findMappingInInterface(
-      AstarteInterface astarteInterface, String path)
+  public AstarteInterfaceMapping findMappingInInterface(String path)
       throws AstarteInterfaceMappingNotFoundException {
 
-    for (Map.Entry<String, AstarteInterfaceMapping> mappingEntry :
-        astarteInterface.getMappings().entrySet()) {
+    for (Map.Entry<String, AstarteInterfaceMapping> mappingEntry : getMappings().entrySet()) {
       if (isPathCompatibleWithMapping(path, mappingEntry.getKey())) {
         return mappingEntry.getValue();
       }
     }
 
     throw new AstarteInterfaceMappingNotFoundException(
-        "Mapping " + path + " not found in interface " + astarteInterface);
+        "Mapping " + path + " not found in interface " + this);
   }
 
-  public static void validatePayload(AstarteInterface astarteInterface, String path, Object payload)
+  public void validatePayload(String path, Object payload, DateTime timestamp)
       throws AstarteInvalidValueException, AstarteInterfaceMappingNotFoundException {
-    validatePayload(astarteInterface, path, payload, null);
-  }
-
-  public static void validatePayload(
-      AstarteInterface astarteInterface, String path, Object payload, DateTime timestamp)
-      throws AstarteInvalidValueException, AstarteInterfaceMappingNotFoundException {
-    validatePayload(findMappingInInterface(astarteInterface, path), payload, timestamp);
-  }
-
-  public static void validatePayload(AstarteInterfaceMapping mapping, Object payload)
-      throws AstarteInvalidValueException {
-    if (!mapping.isTypeCompatible(payload.getClass())) {
-      throw new AstarteInvalidValueException(
-          "Payload type "
-              + payload.getClass()
-              + " is incompatible with mapping type "
-              + mapping.getType());
-    }
-  }
-
-  public static void validatePayload(
-      AstarteInterfaceMapping mapping, Object payload, DateTime timestamp)
-      throws AstarteInvalidValueException {
-    validatePayload(mapping, payload);
-
-    // Act differently depending on the mapping type
-    if (mapping instanceof AstarteInterfaceDatastreamMapping) {
-      AstarteInterfaceDatastreamMapping datastreamMapping =
-          (AstarteInterfaceDatastreamMapping) mapping;
-      if (datastreamMapping.isExplicitTimestamp() && timestamp == null) {
-        throw new AstarteInvalidValueException(
-            "This mapping has an explicit timestamp, " + "but no timestamp has been specified.");
-      }
-    } else if (timestamp != null) {
-      // FIXME: Maybe go easier, and just throw a warning?
-      throw new AstarteInvalidValueException(
-          "When sending a property, explicit timestamp " + "is always ignored");
-    }
-  }
-
-  public static void validateAggregate(
-      AstarteInterface astarteInterface,
-      String pathPrefix,
-      Map<String, Object> payload,
-      DateTime timestamp)
-      throws AstarteInvalidValueException, AstarteInterfaceMappingNotFoundException {
-    // We need to ensure the path list matches
-    if (astarteInterface.getMappings().size() != payload.size()) {
-      throw new AstarteInterfaceMappingNotFoundException(
-          "The interface mapping and the payload don't match.");
-    }
-    for (Map.Entry<String, Object> payloadEntry : payload.entrySet()) {
-      String path = pathPrefix + "/" + payloadEntry.getKey();
-      validatePayload(
-          findMappingInInterface(astarteInterface, path), payloadEntry.getValue(), timestamp);
-    }
+    findMappingInInterface(path).validatePayload(payload, timestamp);
   }
 
   public static boolean isPathCompatibleWithMapping(String path, String mapping) {

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterfaceDatastreamMapping.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterfaceDatastreamMapping.java
@@ -1,5 +1,6 @@
 package org.astarteplatform.devicesdk.protocol;
 
+import org.joda.time.DateTime;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -61,7 +62,7 @@ public class AstarteInterfaceDatastreamMapping extends AstarteInterfaceMapping {
   private MappingRetention retention = MappingRetention.DISCARD;
   private int expiry = 0;
 
-  static AstarteInterfaceDatastreamMapping fromJSON(JSONObject astarteMappingObject)
+  protected static AstarteInterfaceDatastreamMapping fromJSON(JSONObject astarteMappingObject)
       throws JSONException {
     AstarteInterfaceDatastreamMapping astarteInterfaceDatastreamMapping =
         new AstarteInterfaceDatastreamMapping();
@@ -103,5 +104,14 @@ public class AstarteInterfaceDatastreamMapping extends AstarteInterfaceMapping {
 
   public int getExpiry() {
     return expiry;
+  }
+
+  public void validatePayload(Object payload, DateTime timestamp)
+      throws AstarteInvalidValueException {
+    validatePayload(payload);
+    if (isExplicitTimestamp() && timestamp == null) {
+      throw new AstarteInvalidValueException(
+          "This mapping has an explicit timestamp, but no timestamp has been specified.");
+    }
   }
 }

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1Transport.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1Transport.java
@@ -1,61 +1,21 @@
 package org.astarteplatform.devicesdk.transport.mqtt;
 
-import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_BROKER_UNAVAILABLE;
-import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_CLIENT_CLOSED;
-import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_CLIENT_DISCONNECTING;
-import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_CLIENT_EXCEPTION;
-import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_CLIENT_NOT_CONNECTED;
-import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_CLIENT_TIMEOUT;
-import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_CONNECTION_LOST;
-import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_MAX_INFLIGHT;
-import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_WRITE_TIMEOUT;
+import static org.eclipse.paho.client.mqttv3.MqttException.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.zip.InflaterInputStream;
 import org.astarteplatform.devicesdk.AstartePropertyStorageException;
-import org.astarteplatform.devicesdk.protocol.AstarteAggregateDatastreamEvent;
-import org.astarteplatform.devicesdk.protocol.AstarteAggregateDatastreamEventListener;
-import org.astarteplatform.devicesdk.protocol.AstarteAggregateDatastreamInterface;
-import org.astarteplatform.devicesdk.protocol.AstarteDatastreamEvent;
-import org.astarteplatform.devicesdk.protocol.AstarteDatastreamEventListener;
-import org.astarteplatform.devicesdk.protocol.AstarteDatastreamInterface;
-import org.astarteplatform.devicesdk.protocol.AstarteDevicePropertyInterface;
-import org.astarteplatform.devicesdk.protocol.AstarteInterface;
-import org.astarteplatform.devicesdk.protocol.AstarteInterfaceDatastreamMapping;
-import org.astarteplatform.devicesdk.protocol.AstarteInterfaceMapping;
-import org.astarteplatform.devicesdk.protocol.AstarteInterfaceMappingNotFoundException;
-import org.astarteplatform.devicesdk.protocol.AstartePropertyEvent;
-import org.astarteplatform.devicesdk.protocol.AstartePropertyEventListener;
-import org.astarteplatform.devicesdk.protocol.AstarteProtocolType;
-import org.astarteplatform.devicesdk.protocol.AstarteServerAggregateDatastreamInterface;
-import org.astarteplatform.devicesdk.protocol.AstarteServerDatastreamInterface;
-import org.astarteplatform.devicesdk.protocol.AstarteServerPropertyInterface;
+import org.astarteplatform.devicesdk.protocol.*;
 import org.astarteplatform.devicesdk.transport.AstarteFailedMessage;
 import org.astarteplatform.devicesdk.transport.AstarteFailedMessageStorage;
 import org.astarteplatform.devicesdk.transport.AstarteTransportException;
-import org.bson.BSONCallback;
-import org.bson.BSONDecoder;
-import org.bson.BSONObject;
-import org.bson.BasicBSONCallback;
-import org.bson.BasicBSONDecoder;
-import org.bson.BsonBinaryWriter;
-import org.bson.Document;
+import org.bson.*;
 import org.bson.codecs.DocumentCodec;
 import org.bson.codecs.EncoderContext;
 import org.bson.io.BasicOutputBuffer;
-import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
-import org.eclipse.paho.client.mqttv3.IMqttToken;
-import org.eclipse.paho.client.mqttv3.MqttCallback;
-import org.eclipse.paho.client.mqttv3.MqttCallbackExtended;
-import org.eclipse.paho.client.mqttv3.MqttException;
-import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.*;
 import org.joda.time.DateTime;
 
 public class AstarteMqttV1Transport extends AstarteMqttTransport {
@@ -352,9 +312,7 @@ public class AstarteMqttV1Transport extends AstarteMqttTransport {
     if (astarteInterface instanceof AstarteDatastreamInterface) {
       try {
         // Find a matching mapping
-        mapping =
-            (AstarteInterfaceDatastreamMapping)
-                AstarteInterface.findMappingInInterface(astarteInterface, path);
+        mapping = (AstarteInterfaceDatastreamMapping) astarteInterface.findMappingInInterface(path);
       } catch (AstarteInterfaceMappingNotFoundException e) {
         throw new AstarteTransportException("Mapping not found", e);
       }

--- a/DeviceSDK/src/test/java/org/astarteplatform/devicesdk/protocol/AstarteDeviceAggregateDatastreamInterfaceTest.java
+++ b/DeviceSDK/src/test/java/org/astarteplatform/devicesdk/protocol/AstarteDeviceAggregateDatastreamInterfaceTest.java
@@ -1,0 +1,95 @@
+package org.astarteplatform.devicesdk.protocol;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.astarteplatform.devicesdk.AstartePropertyStorage;
+import org.joda.time.DateTime;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AstarteDeviceAggregateDatastreamInterfaceTest {
+  AstarteDeviceAggregateDatastreamInterface aInterface;
+
+  @Before
+  public void init() throws AstarteInvalidInterfaceException {
+    JSONObject json =
+        new JSONObject(
+            "{\n"
+                + "    \"interface_name\": \"com.astarte.Test\",\n"
+                + "    \"version_major\": 0,\n"
+                + "    \"version_minor\": 1,\n"
+                + "    \"type\": \"datastream\",\n"
+                + "    \"ownership\": \"device\",\n"
+                + "    \"aggregation\": \"object\",\n"
+                + "    \"mappings\": [\n"
+                + "        {\n"
+                + "            \"endpoint\": \"/test/uno\",\n"
+                + "            \"type\": \"integer\",\n"
+                + "            \"database_retention_policy\": \"use_ttl\",\n"
+                + "            \"database_retention_ttl\": 31536000, \n"
+                + "            \"explicit_timestamp\": true\n"
+                + "        },\n"
+                + "        {\n"
+                + "            \"endpoint\": \"/test/due\",\n"
+                + "            \"type\": \"integer\",\n"
+                + "            \"database_retention_policy\": \"use_ttl\",\n"
+                + "            \"database_retention_ttl\": 31536000, \n"
+                + "            \"explicit_timestamp\": true\n"
+                + "        }\n"
+                + "    ]\n"
+                + "}");
+    AstartePropertyStorage storage = mock(AstartePropertyStorage.class);
+    aInterface =
+        (AstarteDeviceAggregateDatastreamInterface) AstarteInterface.fromJSON(json, storage);
+  }
+
+  @Test
+  public void validateAggregateTest()
+      throws AstarteInvalidValueException, AstarteInterfaceMappingNotFoundException {
+    Map<String, Object> payload = new HashMap<>();
+    payload.put("uno", 1);
+    payload.put("due", 2);
+    aInterface.validatePayload("/test", payload, DateTime.now());
+  }
+
+  @Test
+  public void validateAggregateLTooFewPayloadTest()
+      throws AstarteInterfaceMappingNotFoundException {
+    Map<String, Object> payload = new HashMap<>();
+    payload.put("uno", 1);
+    try {
+      aInterface.validatePayload("/test", payload, DateTime.now());
+    } catch (AstarteInvalidValueException ex) {
+      System.out.println(ex.getMessage());
+    }
+  }
+
+  @Test
+  public void validateAggregateTooMuchPayloadTest() throws AstarteInvalidValueException {
+    Map<String, Object> payload = new HashMap<>();
+    payload.put("uno", 1);
+    payload.put("due", 2);
+    payload.put("tre", 3);
+    try {
+      aInterface.validatePayload("/test", payload, DateTime.now());
+    } catch (AstarteInterfaceMappingNotFoundException ex) {
+      System.out.println(ex.getMessage());
+    }
+  }
+
+  @Test
+  public void validateAggregateTimestampRequiredTest()
+      throws AstarteInvalidValueException, AstarteInterfaceMappingNotFoundException {
+    Map<String, Object> payload = new HashMap<>();
+    payload.put("uno", 1);
+    payload.put("due", 2);
+    try {
+      aInterface.validatePayload("/test", payload, null);
+    } catch (AstarteInvalidValueException ex) {
+      System.out.println(ex.getMessage());
+    }
+  }
+}

--- a/DeviceSDK/src/test/java/org/astarteplatform/devicesdk/protocol/AstarteDevicePropertyInterfaceTest.java
+++ b/DeviceSDK/src/test/java/org/astarteplatform/devicesdk/protocol/AstarteDevicePropertyInterfaceTest.java
@@ -1,0 +1,75 @@
+package org.astarteplatform.devicesdk.protocol;
+
+import static org.mockito.Mockito.mock;
+
+import org.astarteplatform.devicesdk.AstartePropertyStorage;
+import org.joda.time.DateTime;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AstarteDevicePropertyInterfaceTest {
+  AstarteDevicePropertyInterface aInterface;
+
+  @Before
+  public void init() throws AstarteInvalidInterfaceException {
+    JSONObject json =
+        new JSONObject(
+            "{\n"
+                + "    \"interface_name\": \"com.astarte.Test\",\n"
+                + "    \"version_major\": 0,\n"
+                + "    \"version_minor\": 1,\n"
+                + "    \"type\": \"properties\",\n"
+                + "    \"ownership\": \"device\",\n"
+                + "    \"mappings\": [\n"
+                + "        {\n"
+                + "            \"endpoint\": \"/test/uno\",\n"
+                + "            \"type\": \"integer\",\n"
+                + "            \"database_retention_policy\": \"use_ttl\",\n"
+                + "            \"database_retention_ttl\": 31536000 \n"
+                + "        },\n"
+                + "        {\n"
+                + "            \"endpoint\": \"/test/due\",\n"
+                + "            \"type\": \"integer\",\n"
+                + "            \"database_retention_policy\": \"use_ttl\",\n"
+                + "            \"database_retention_ttl\": 31536000 \n"
+                + "        }\n"
+                + "    ]\n"
+                + "}");
+    AstartePropertyStorage storage = mock(AstartePropertyStorage.class);
+    aInterface = (AstarteDevicePropertyInterface) AstarteInterface.fromJSON(json, storage);
+  }
+
+  @Test
+  public void validatePropertyTest()
+      throws AstarteInvalidValueException, AstarteInterfaceMappingNotFoundException {
+    aInterface.validatePayload("/test/uno", 1, null);
+  }
+
+  @Test
+  public void validatePropertyInvalidValueTest() throws AstarteInterfaceMappingNotFoundException {
+    try {
+      aInterface.validatePayload("/test/uno", 1.0, null);
+    } catch (AstarteInvalidValueException ex) {
+      System.out.println(ex.getMessage());
+    }
+  }
+
+  @Test
+  public void validateAbsentPropertyTest() throws AstarteInvalidValueException {
+    try {
+      aInterface.validatePayload("/test/tre", 3, null);
+    } catch (AstarteInterfaceMappingNotFoundException e) {
+      System.out.println(e.getMessage());
+    }
+  }
+
+  @Test
+  public void validatePropertyTimestampTest() throws AstarteInterfaceMappingNotFoundException {
+    try {
+      aInterface.validatePayload("/test/uno", 1, DateTime.now());
+    } catch (AstarteInvalidValueException ex) {
+      System.out.println(ex.getMessage());
+    }
+  }
+}

--- a/DeviceSDK/src/test/java/org/astarteplatform/devicesdk/protocol/AstarteInterfaceMappingTest.java
+++ b/DeviceSDK/src/test/java/org/astarteplatform/devicesdk/protocol/AstarteInterfaceMappingTest.java
@@ -1,0 +1,217 @@
+package org.astarteplatform.devicesdk.protocol;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.joda.time.DateTime;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class AstarteInterfaceMappingTest {
+
+  @Test
+  public void typeInt() {
+    String interf =
+        "{\n" + "     \"endpoint\": \"/integer\",\n" + "     \"type\": \"integer\",\n" + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertTrue("mapping type integer", astarteInterfaceMapping.isTypeCompatible(Integer.class));
+  }
+
+  @Test
+  public void typeBadInt() {
+    String interf =
+        "{\n" + "     \"endpoint\": \"/integer\",\n" + "     \"type\": \"integer\",\n" + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertFalse(
+        "mapping type integer with wrong type",
+        astarteInterfaceMapping.isTypeCompatible(String.class));
+  }
+
+  @Test
+  public void typeString() {
+    String interf =
+        "{\n" + "     \"endpoint\": \"/string\",\n" + "     \"type\": \"string\",\n" + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertTrue("mapping type string", astarteInterfaceMapping.isTypeCompatible(String.class));
+  }
+
+  @Test
+  public void typeBadString() {
+    String interf =
+        "{\n" + "     \"endpoint\": \"/string\",\n" + "     \"type\": \"string\",\n" + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertFalse(
+        "mapping type string with wrong type",
+        astarteInterfaceMapping.isTypeCompatible(Integer.class));
+  }
+
+  @Test
+  public void typeDouble() {
+    String interf =
+        "{\n" + "     \"endpoint\": \"/double\",\n" + "     \"type\": \"double\",\n" + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertTrue("mapping type double", astarteInterfaceMapping.isTypeCompatible(Double.class));
+  }
+
+  @Test
+  public void typeBadDouble() {
+    String interf =
+        "{\n" + "     \"endpoint\": \"/double\",\n" + "     \"type\": \"double\",\n" + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertFalse(
+        "mapping type double with wrong type",
+        astarteInterfaceMapping.isTypeCompatible(String.class));
+  }
+
+  @Test
+  public void typeLongInteger() {
+    String interf =
+        "{\n"
+            + "     \"endpoint\": \"/longinteger\",\n"
+            + "     \"type\": \"longinteger\",\n"
+            + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertTrue("mapping type Long", astarteInterfaceMapping.isTypeCompatible(Long.class));
+  }
+
+  @Test
+  public void typeBadLongInteger() {
+    String interf =
+        "{\n"
+            + "     \"endpoint\": \"/longinteger\",\n"
+            + "     \"type\": \"longinteger\",\n"
+            + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertFalse(
+        "mapping type Long with wrong type",
+        astarteInterfaceMapping.isTypeCompatible(String.class));
+  }
+
+  @Test
+  public void typeBoolean() {
+    String interf =
+        "{\n" + "     \"endpoint\": \"/boolean\",\n" + "     \"type\": \"boolean\",\n" + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertTrue("mapping type boolean", astarteInterfaceMapping.isTypeCompatible(Boolean.class));
+  }
+
+  @Test
+  public void typeBadBoolean() {
+    String interf =
+        "{\n" + "     \"endpoint\": \"/boolean\",\n" + "     \"type\": \"boolean\",\n" + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertFalse(
+        "mapping type boolean with wrong type",
+        astarteInterfaceMapping.isTypeCompatible(String.class));
+  }
+
+  @Test
+  public void typeBinaryBlob() {
+    String interf =
+        "{\n"
+            + "     \"endpoint\": \"/binaryblob\",\n"
+            + "     \"type\": \"binaryblob\",\n"
+            + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertTrue("mapping type binaryblob", astarteInterfaceMapping.isTypeCompatible(Byte[].class));
+  }
+
+  @Test
+  public void typeBadBinaryBlob() {
+    String interf =
+        "{\n"
+            + "     \"endpoint\": \"/binaryblob\",\n"
+            + "     \"type\": \"binaryblob\",\n"
+            + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertFalse(
+        "mapping type binaryblob with wrong type",
+        astarteInterfaceMapping.isTypeCompatible(String.class));
+  }
+
+  @Test
+  public void typeDatetime() {
+    String interf =
+        "{\n" + "     \"endpoint\": \"/datetime\",\n" + "     \"type\": \"datetime\",\n" + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertTrue("mapping type datetime", astarteInterfaceMapping.isTypeCompatible(DateTime.class));
+  }
+
+  @Test
+  public void typeBadDatetime() {
+    String interf =
+        "{\n" + "     \"endpoint\": \"/datetime\",\n" + "     \"type\": \"datetime\",\n" + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    assertFalse(
+        "mapping type datetime with wrong type",
+        astarteInterfaceMapping.isTypeCompatible(String.class));
+  }
+
+  @Test
+  public void ValidateDouble() throws AstarteInvalidValueException {
+    String interf =
+        "{\n" + "     \"endpoint\": \"/double\",\n" + "     \"type\": \"double\",\n" + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    astarteInterfaceMapping.validatePayload(3.0);
+  }
+
+  @Test
+  public void ValidateNaNDouble() {
+    String interf =
+        "{\n" + "     \"endpoint\": \"/double\",\n" + "     \"type\": \"double\",\n" + "   }\n";
+
+    JSONObject jsonInterface = new JSONObject(interf);
+    AstarteInterfaceMapping astarteInterfaceMapping =
+        AstarteInterfaceMapping.fromJSON(jsonInterface);
+    try {
+      astarteInterfaceMapping.validatePayload(Double.NaN);
+    } catch (AstarteInvalidValueException e) {
+      System.out.println(e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
- Rework "isTypeCompatible" to strictly ensure typing
- Rename "validateAggregate" to "validatePayload"
- Remove "static" keyword on "validatePayload" as it is often called with "this" as first parameter"
- Moved each "validatePayload" in relative class for cleaner code
- Add tests on data validation
- Fix #26 
- Fix #27 
- Fix #28


Signed-off-by: Francesco Vaiani <francesco.vaiani@seco.com>