### PR TITLE
Remove redundant field initializer

### DIFF
--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstarteDevice.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstarteDevice.java
@@ -19,7 +19,7 @@ public abstract class AstarteDevice {
   private final Map<String, AstarteInterface> mAstarteInterfaces;
   protected final AstartePropertyStorage mPropertyStorage;
   protected final AstarteFailedMessageStorage mFailedMessageStorage;
-  protected boolean mAlwaysReconnect = false;
+  protected boolean mAlwaysReconnect;
 
   AstarteDevice(
       AstarteInterfaceProvider astarteInterfaceProvider,

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
@@ -13,11 +13,11 @@ import org.json.JSONException;
 public abstract class AstartePairableDevice extends AstarteDevice
     implements AstarteTransportEventListener {
   private AstartePairingHandler mPairingHandler;
-  private AstarteTransport mAstarteTransport = null;
-  private AstarteMessageListener mAstarteMessageListener = null;
-  private boolean mInitialized = false;
-  private boolean mExplicitDisconnectionRequest = false;
-  private java.util.Timer mReconnectTimer = null;
+  private AstarteTransport mAstarteTransport;
+  private AstarteMessageListener mAstarteMessageListener;
+  private boolean mInitialized;
+  private boolean mExplicitDisconnectionRequest;
+  private java.util.Timer mReconnectTimer;
 
   protected AstartePairableDevice(
       AstartePairingHandler pairingHandler,

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterfaceDatastreamMapping.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterfaceDatastreamMapping.java
@@ -56,10 +56,10 @@ public class AstarteInterfaceDatastreamMapping extends AstarteInterfaceMapping {
     }
   }
 
-  private boolean explicitTimestamp = false;
+  private boolean explicitTimestamp;
   private MappingReliability reliability = MappingReliability.UNRELIABLE;
   private MappingRetention retention = MappingRetention.DISCARD;
-  private int expiry = 0;
+  private int expiry;
 
   static AstarteInterfaceDatastreamMapping fromJSON(JSONObject astarteMappingObject)
       throws JSONException {

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/AstarteTransport.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/AstarteTransport.java
@@ -13,11 +13,11 @@ import org.astarteplatform.devicesdk.protocol.AstarteProtocolType;
 public abstract class AstarteTransport implements AstarteProtocol {
   private final AstarteProtocolType m_astarteProtocolType;
   private AstarteDevice mDevice;
-  protected boolean m_introspectionSent = false;
-  protected AstartePropertyStorage m_propertyStorage = null;
-  protected AstarteFailedMessageStorage m_failedMessageStorage = null;
-  protected AstarteMessageListener m_messageListener = null;
-  protected AstarteTransportEventListener m_astarteTransportEventListener = null;
+  protected boolean m_introspectionSent;
+  protected AstartePropertyStorage m_propertyStorage;
+  protected AstarteFailedMessageStorage m_failedMessageStorage;
+  protected AstarteMessageListener m_messageListener;
+  protected AstarteTransportEventListener m_astarteTransportEventListener;
 
   protected AstarteTransport(AstarteProtocolType type) {
     m_astarteProtocolType = type;

--- a/DeviceSDKGeneric/src/main/java/org/astarteplatform/devicesdk/generic/AstarteGenericCryptoStore.java
+++ b/DeviceSDKGeneric/src/main/java/org/astarteplatform/devicesdk/generic/AstarteGenericCryptoStore.java
@@ -24,9 +24,9 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 
 class AstarteGenericCryptoStore implements AstarteCryptoStore {
-  private KeyPair m_keyPair = null;
-  private Certificate m_certificate = null;
-  private AstarteGenericMutualSSLSocketFactory m_socketFactory = null;
+  private KeyPair m_keyPair;
+  private Certificate m_certificate;
+  private AstarteGenericMutualSSLSocketFactory m_socketFactory;
 
   public AstarteGenericCryptoStore() {
     // TODO: this does not store credentials in a KeyStore


### PR DESCRIPTION
Java will initialize fields(static or instance variable inside class) with known default values
so any explicit initialization of those same defaults is redundant
and results in a larger class file (approximately three additional bytecode instructions per field).
It doesn't count for local variables defined within a method,
they must be initialized before use. They do not have a default value.

See [datatypes-default](https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html).

Signed-off-by: Antonio Gisondi <antonio.gisondi@secomind.com>