### PR TITLE
Add a check on certificate availability before connect.

### DIFF
--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
@@ -117,6 +117,10 @@ public abstract class AstartePairableDevice extends AstarteDevice
         return;
       }
 
+      if (!mPairingHandler.isCertificateAvailable()) {
+        mPairingHandler.requestNewCertificate();
+      }
+
       try {
         mAstarteTransport.connect();
       } catch (AstarteCryptoException e) {

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairingHandler.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairingHandler.java
@@ -1,6 +1,8 @@
 package org.astarteplatform.devicesdk;
 
 import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Date;
 import java.util.List;
 import org.astarteplatform.devicesdk.crypto.AstarteCryptoStore;
 import org.astarteplatform.devicesdk.transport.AstarteTransport;
@@ -52,7 +54,22 @@ public class AstartePairingHandler {
   }
 
   public boolean isCertificateAvailable() {
-    return m_cryptoStore.getCertificate() != null;
+    final Certificate certificate = m_cryptoStore.getCertificate();
+    if (certificate == null) {
+      return false;
+    }
+
+    if (certificate instanceof X509Certificate) {
+      final Date notBefore = ((X509Certificate) certificate).getNotBefore();
+      final Date notAfter = ((X509Certificate) certificate).getNotAfter();
+      final Date now = new Date();
+
+      return notBefore.before(now) && notAfter.after(now);
+    }
+
+    // in the remote case it is not a x509 certificate we fall back on the previous behaviour to
+    // only chek if certificate is present
+    return true;
   }
 
   private void reloadTransports() throws AstartePairingException {


### PR DESCRIPTION
During the first connection ever the SDK always throws an exception because it tries to establish a connection to the MQTT before a certificate is issued.

The end goal is to prevent log pollution and fix a predictable exception.
To do so a check to `isCertificateAvalaible()` is now called before connecting and eventually, if it returns `false`, a new certificate is requested.
On top of that, a check on x509 certificate validity is inquired so a new certificate is requested even if the file is actually present but it's expired.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>