### PR TITLE
Fixed DateTime handling in BSON serialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.1.0-dev] - Unreleased
 ### Added
 - Add support to array-type endpoints.
+- Add support for multiple date formats for datetime and datetimearray values
 - Sending data on an endpoint not present in interface now triggers an exception.
 - Sending an object with fewer data than needed now triggers an exception.
 - Sending a non-numeric value on an endpoint with type Double now triggers an exception.

--- a/DeviceSDK/src/test/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1TransportTest.java
+++ b/DeviceSDK/src/test/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1TransportTest.java
@@ -61,16 +61,26 @@ public class AstarteMqttV1TransportTest {
   public void mapArrayToEncodedBSONTest() {
     Map<String, Object> m = new HashMap<>();
     Integer[] intarray = {1, 2, 3};
+    DateTime now = new DateTime();
+    DateTime[] dateTimeArray = {now, now};
     m.put("/intarray", intarray);
     m.put("/double", 1.0);
     m.put("/string", "s");
+    m.put("/datetime", now);
+    m.put("/datetimearray", dateTimeArray);
     final byte[] encodedPayload =
         AstartePayload.serialize(m, new DateTime(System.currentTimeMillis()).toDate());
     final DecodedMessage decodedMessage =
         AstartePayload.deserialize(encodedPayload, mBSONDecoder, mBSONCallback);
-    Object decodedArray = ((Map<String, Object>) decodedMessage.getPayload()).get("/intarray");
-    assertTrue("validate deserialized Integer ", decodedArray instanceof Integer[]);
-    assertArrayEquals((Integer[]) m.get("/intarray"), (Integer[]) decodedArray);
+    final Map<String, Object> decodedMessagePayload =
+        (Map<String, Object>) decodedMessage.getPayload();
+    Object decodedIntArray = decodedMessagePayload.get("/intarray");
+    Object decodedDateTimeArray = decodedMessagePayload.get("/datetimearray");
+    Object decodedDateTime = decodedMessagePayload.get("/datetime");
+    assertTrue("validate deserialized Integer ", decodedIntArray instanceof Integer[]);
+    assertArrayEquals((Integer[]) m.get("/intarray"), (Integer[]) decodedIntArray);
+    assertArrayEquals((DateTime[]) m.get("/datetimearray"), (DateTime[]) decodedDateTimeArray);
+    assertEquals(m.get("/datetime"), decodedDateTime);
   }
 
   @Test
@@ -81,7 +91,7 @@ public class AstarteMqttV1TransportTest {
     final byte[] encodedPayload = AstartePayload.serialize(b, null);
     final DecodedMessage decodedMessage =
         AstartePayload.deserialize(encodedPayload, mBSONDecoder, mBSONCallback);
-    assertTrue("validate deserialized Integer ", decodedMessage.getPayload() instanceof byte[]);
+    assertTrue("validate deserialized bson ", decodedMessage.getPayload() instanceof byte[]);
     assertArrayEquals(b, (byte[]) decodedMessage.getPayload());
   }
 
@@ -95,7 +105,28 @@ public class AstarteMqttV1TransportTest {
     final byte[] encodedPayload = AstartePayload.serialize(b, null);
     final DecodedMessage decodedMessage =
         AstartePayload.deserialize(encodedPayload, mBSONDecoder, mBSONCallback);
-    assertTrue("validate deserialized Integer ", decodedMessage.getPayload() instanceof byte[][]);
+    assertTrue("validate deserialized bsonArray ", decodedMessage.getPayload() instanceof byte[][]);
     assertArrayEquals(b, (byte[][]) decodedMessage.getPayload());
+  }
+
+  @Test
+  public void datetimeToEncodedBSONTest() {
+    final DateTime d = new DateTime();
+    final byte[] encodedPayload = AstartePayload.serialize(d, null);
+    final DecodedMessage decodedMessage =
+        AstartePayload.deserialize(encodedPayload, mBSONDecoder, mBSONCallback);
+    assertTrue("validate deserialized Datetime ", decodedMessage.getPayload() instanceof DateTime);
+    assertEquals(d, (DateTime) decodedMessage.getPayload());
+  }
+
+  @Test
+  public void datetimeArrayToEncodedBSONTest() {
+    final DateTime[] d = {new DateTime(), new DateTime()};
+    final byte[] encodedPayload = AstartePayload.serialize(d, null);
+    final DecodedMessage decodedMessage =
+        AstartePayload.deserialize(encodedPayload, mBSONDecoder, mBSONCallback);
+    assertTrue(
+        "validate deserialized Datetime Array ", decodedMessage.getPayload() instanceof DateTime[]);
+    assertArrayEquals(d, (DateTime[]) decodedMessage.getPayload());
   }
 }

--- a/DeviceSDKAndroid/src/androidTest/java/org/astarteplatform/devicesdk/android/AstarteAndroidPropertyStorageTest.java
+++ b/DeviceSDKAndroid/src/androidTest/java/org/astarteplatform/devicesdk/android/AstarteAndroidPropertyStorageTest.java
@@ -12,6 +12,7 @@ import org.bson.BSONCallback;
 import org.bson.BSONDecoder;
 import org.bson.BasicBSONCallback;
 import org.bson.BasicBSONDecoder;
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,5 +72,19 @@ public class AstarteAndroidPropertyStorageTest {
 
     assertTrue("validate deserialized Integer Array", decoded instanceof byte[][]);
     assertArrayEquals(value, (byte[][]) decoded);
+  }
+
+  @Test
+  public void testSerializeDateTime() {
+    when(mapping.getType()).thenReturn(DateTime.class);
+    DateTime value = new DateTime();
+    final SharedPreferences preferences =
+        this.context.getSharedPreferences("astarte.property_store.test", Context.MODE_PRIVATE);
+    AstarteAndroidPropertyStorage.put(preferences, key, value);
+    final Object decoded =
+        AstarteAndroidPropertyStorage.get(preferences, mapping, key, mBSONDecoder, mBSONCallback);
+
+    assertTrue("validate deserialized Integer Array", decoded instanceof DateTime);
+    assertEquals(value, decoded);
   }
 }

--- a/DeviceSDKGeneric/src/test/java/org/astarteplatform/devicesdk/generic/AstarteGenericPropertyStorageTest.java
+++ b/DeviceSDKGeneric/src/test/java/org/astarteplatform/devicesdk/generic/AstarteGenericPropertyStorageTest.java
@@ -2,7 +2,6 @@ package org.astarteplatform.devicesdk.generic;
 
 import static org.junit.Assert.*;
 
-import java.util.Date;
 import org.astarteplatform.devicesdk.util.AstartePayload;
 import org.bson.*;
 import org.bson.types.Decimal128;
@@ -80,7 +79,7 @@ public class AstarteGenericPropertyStorageTest {
 
   @Test
   public void testSerializeDate() {
-    Date dateExpected = new DateTime(System.currentTimeMillis()).toDate();
+    DateTime dateExpected = new DateTime(System.currentTimeMillis());
 
     byte[] serialized = AstartePayload.serialize(dateExpected, null);
     Object dateDes =


### PR DESCRIPTION
It looked like the Datetime and Datetime[] values were not correctly handled in the serialization function.
A function was created to normalize the payload and replace all DateTime values with java.util.Date values for easier serialization.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>