### PR TITLE
Rewrite registerDevice for Android API 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ This SDK should be used to connect any device running Android (or any Java appli
 Virtually an SDK is not required to connect an application to Astarte using MQTT, but it enables
 rapid development and a pleasant developer experience.
 
+## Requirements
+### Device SDK Android
+- Android system API level >= 23 (Android 6.0).
+
+### Device SDK Generic
+- Java version >= 1.8.
+
 ## Usage
 
 See the `examples` folder for usage examples.


### PR DESCRIPTION
Scanning the project I found out that in the method `registerDevice` the `Optional` class is used to describe a nullable object. Unluckily the `Optional` class was added in API Level 24 ([see documentation](https://developer.android.com/reference/java/util/Optional#ofNullable(T)))  and it can't be used because `minSdkVersion 23` is declared in `DeviceSDKAndroid/build.gradle`.
This commit replaces the `Optional` class with a couple of not equally elegant, but working, `== null` checks.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>