### PR TITLE
Add dynamic interface load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.4] - Unreleased
 ### Added
 - Add check that prevents sending an interface with both major and minor version set to 0
+- Add capability to dynamically update the introspection
 
 ## [1.0.3] - 2022-07-05
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstarteInterfaceProvider.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstarteInterfaceProvider.java
@@ -5,4 +5,6 @@ import org.json.JSONObject;
 
 public interface AstarteInterfaceProvider {
   Collection<JSONObject> loadAllInterfaces();
+
+  JSONObject loadInterface(String interfaceName);
 }

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
@@ -3,12 +3,15 @@ package org.astarteplatform.devicesdk;
 import org.astarteplatform.devicesdk.crypto.AstarteCryptoException;
 import org.astarteplatform.devicesdk.crypto.AstarteCryptoStore;
 import org.astarteplatform.devicesdk.protocol.AstarteInterface;
+import org.astarteplatform.devicesdk.protocol.AstarteInterfaceAlreadyPresentException;
+import org.astarteplatform.devicesdk.protocol.AstarteInterfaceNotFoundException;
 import org.astarteplatform.devicesdk.protocol.AstarteInvalidInterfaceException;
 import org.astarteplatform.devicesdk.transport.AstarteFailedMessageStorage;
 import org.astarteplatform.devicesdk.transport.AstarteTransport;
 import org.astarteplatform.devicesdk.transport.AstarteTransportEventListener;
 import org.astarteplatform.devicesdk.transport.AstarteTransportException;
 import org.json.JSONException;
+import org.json.JSONObject;
 
 public abstract class AstartePairableDevice extends AstarteDevice
     implements AstarteTransportEventListener {
@@ -282,6 +285,51 @@ public abstract class AstartePairableDevice extends AstarteDevice
     // Set transport on all interfaces
     for (AstarteInterface astarteInterface : getAllInterfaces()) {
       astarteInterface.setAstarteTransport(mAstarteTransport);
+    }
+  }
+
+  /**
+   * Method that adds an interface dynamically to the introspection. If the device is connected the
+   * updated introspection is sent to the server.
+   *
+   * @param astarteInterfaceObject the JSONObject representation of the interface
+   * @throws AstarteInvalidInterfaceException when the JSON Object does not represent an interface
+   *     correctly
+   * @throws AstarteInterfaceAlreadyPresentException when an interface with the same name, major and
+   *     minor is already present
+   */
+  @Override
+  public void addInterface(JSONObject astarteInterfaceObject)
+      throws AstarteInvalidInterfaceException, AstarteInterfaceAlreadyPresentException {
+    super.addInterface(astarteInterfaceObject);
+    if (isConnected()) {
+      String interfaceName = astarteInterfaceObject.getString("interface_name");
+      AstarteInterface astarteInterface = getInterface(interfaceName);
+      astarteInterface.setAstarteTransport(mAstarteTransport);
+      try {
+        mAstarteTransport.sendIntrospection();
+      } catch (AstarteTransportException e) {
+        onTransportConnectionInitializationError(e);
+      }
+    }
+  }
+
+  /**
+   * Method that dynamically removes an interface from the introspection. If the device is
+   * connected, the updated introspection is sent to the server.
+   *
+   * @param interfaceName The name of the interface to remove
+   * @throws AstarteInterfaceNotFoundException when no interface is found with the given name
+   */
+  @Override
+  public void removeInterface(String interfaceName) throws AstarteInterfaceNotFoundException {
+    super.removeInterface(interfaceName);
+    if (isConnected()) {
+      try {
+        mAstarteTransport.sendIntrospection();
+      } catch (AstarteTransportException e) {
+        onTransportConnectionInitializationError(e);
+      }
     }
   }
 }

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterfaceAlreadyPresentException.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterfaceAlreadyPresentException.java
@@ -1,0 +1,7 @@
+package org.astarteplatform.devicesdk.protocol;
+
+public class AstarteInterfaceAlreadyPresentException extends Exception {
+  public AstarteInterfaceAlreadyPresentException(String text) {
+    super(text);
+  }
+}

--- a/DeviceSDKAndroid/src/androidTest/java/org/astarteplatform/devicesdk/TestInterfaceProvider.java
+++ b/DeviceSDKAndroid/src/androidTest/java/org/astarteplatform/devicesdk/TestInterfaceProvider.java
@@ -46,4 +46,9 @@ public class TestInterfaceProvider implements AstarteInterfaceProvider {
     }
     return interfaces;
   }
+
+  @Override
+  public JSONObject loadInterface(String interfaceName) {
+    return null;
+  }
 }

--- a/DeviceSDKGeneric/src/intTest/java/org/astarteplatform/devicesdk/generic/TestInterfaceProvider.java
+++ b/DeviceSDKGeneric/src/intTest/java/org/astarteplatform/devicesdk/generic/TestInterfaceProvider.java
@@ -47,4 +47,9 @@ public class TestInterfaceProvider implements AstarteInterfaceProvider {
     }
     return interfaces;
   }
+
+  @Override
+  public JSONObject loadInterface(String interfaceName) {
+    return null;
+  }
 }

--- a/examples/Android/src/main/java/org/astarteplatform/devicesdk/android/examples/ExampleInterfaceProvider.java
+++ b/examples/Android/src/main/java/org/astarteplatform/devicesdk/android/examples/ExampleInterfaceProvider.java
@@ -42,6 +42,11 @@ public class ExampleInterfaceProvider implements AstarteInterfaceProvider {
     return interfaces;
   }
 
+  @Override
+  public JSONObject loadInterface(String interfaceName) {
+    return null;
+  }
+
   private String loadJSONFromAsset(String interfaceName) {
     String json = null;
     try {

--- a/examples/Generic/src/main/java/org/astarteplatform/devicesdk/generic/examples/ExampleDevice.java
+++ b/examples/Generic/src/main/java/org/astarteplatform/devicesdk/generic/examples/ExampleDevice.java
@@ -92,14 +92,10 @@ public class ExampleDevice {
      * class for more details
      */
     JdbcConnectionSource connectionSource = new JdbcConnectionSource("jdbc:h2:mem:testDb");
+    ExampleInterfaceProvider interfaceProvider = new ExampleInterfaceProvider();
     AstarteDevice device =
         new AstarteGenericDevice(
-            deviceId,
-            realm,
-            credentialsSecret,
-            new ExampleInterfaceProvider(),
-            pairingUrl,
-            connectionSource);
+            deviceId, realm, credentialsSecret, interfaceProvider, pairingUrl, connectionSource);
     /*
      * Connect listeners
      *
@@ -147,6 +143,8 @@ public class ExampleDevice {
      *
      * Retrieve the interface from the device and call streamData on it.
      */
+    device.addInterface(interfaceProvider.loadInterface(valuesInterfaceName));
+
     AstarteDeviceDatastreamInterface valuesInterface =
         (AstarteDeviceDatastreamInterface) device.getInterface(valuesInterfaceName);
 

--- a/examples/Generic/src/main/java/org/astarteplatform/devicesdk/generic/examples/ExampleInterfaceProvider.java
+++ b/examples/Generic/src/main/java/org/astarteplatform/devicesdk/generic/examples/ExampleInterfaceProvider.java
@@ -20,23 +20,35 @@ public class ExampleInterfaceProvider implements AstarteInterfaceProvider {
      */
     String[] interfaceNames = {
       "org.astarte-platform.genericsensors.AvailableSensors",
-      "org.astarte-platform.genericsensors.SamplingRate",
-      "org.astarte-platform.genericsensors.Values"
+      "org.astarte-platform.genericsensors.SamplingRate"
     };
     Collection<JSONObject> interfaces = new HashSet<>();
 
     for (String interfaceName : interfaceNames) {
-      InputStream is =
-          ClassLoader.getSystemClassLoader()
-              .getResourceAsStream("standard-interfaces/" + interfaceName + ".json");
-      JSONTokener tokener = new JSONTokener(is);
-
       try {
-        interfaces.add(new JSONObject(tokener));
+        interfaces.add(loadInterface(interfaceName));
       } catch (Exception e) {
         e.printStackTrace();
       }
     }
     return interfaces;
+  }
+
+  @Override
+  public JSONObject loadInterface(String interfaceName) {
+    /*
+     * loadInterface must return the interface witch the given interface name.
+     *
+     * Here we load the interface from JSON files that is in the resource folder.
+     *
+     */
+    InputStream is =
+        ClassLoader.getSystemClassLoader()
+            .getResourceAsStream("standard-interfaces/" + interfaceName + ".json");
+    if (is == null) {
+      return null;
+    }
+    JSONTokener tokener = new JSONTokener(is);
+    return new JSONObject(tokener);
   }
 }


### PR DESCRIPTION
Add the capability to load and unload interfaces dynamically in the device's introspection calling the `addInterface` and `removeInterface` functions of the `AstarteDevice` class. 
The `AstartePairableDevice` class extends said functions to add the capability to send the altered introspection to the server if the device is connected. 
The function `loadInterface` in the `InterfaceProvider` can be implemented to help load interfaces by name and instantiate them to `JSONObject`, similarly to what the `loadAllInterfaces` function does for a batch of interfaces, as shown in the `ExampleInterfaceProvider` example implementation.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>