### PR TITLE
Add Sonatype publications to CI

### DIFF
--- a/.github/workflows/sonatype-publish.yaml
+++ b/.github/workflows/sonatype-publish.yaml
@@ -1,0 +1,61 @@
+name: Sonatype publication with Gradle
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  sonatype-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      #Run JDK configuration
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      #Gradle cache configuration
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      #Authorizing gradlew files
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      #Build project
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      #After decoding the secret key, place the file in / tmp / secring.gpg
+      - name: Decode
+        run: |
+          echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gradle/secring.gpg.b64
+          base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
+
+      #Publish project
+      - name: Publish DeviceSDK
+        run: ./gradlew DeviceSDK:publish -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
+        env:
+          OSSRH_USERNAME: ${{secrets.OSSRH_USERNAME}}
+          OSSRH_PASSWORD: ${{secrets.OSSRH_PASSWORD}}
+          SONATYPE_STAGING_PROFILE_ID: ${{secrets.SONATYPE_STAGING_PROFILE_ID}}
+          SIGNING_KEY_ID: ${{secrets.SIGNING_KEY_ID}}
+      - name: Publish DeviceSDKAndroid -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
+        run: ./gradlew DeviceSDKAndroid:publish
+        env:
+          OSSRH_USERNAME: ${{secrets.OSSRH_USERNAME}}
+          OSSRH_PASSWORD: ${{secrets.OSSRH_PASSWORD}}
+          SONATYPE_STAGING_PROFILE_ID: ${{secrets.SONATYPE_STAGING_PROFILE_ID}}
+          SIGNING_KEY_ID: ${{secrets.SIGNING_KEY_ID}}
+      - name: Publish DeviceSDKGeneric
+        run: ./gradlew DeviceSDKGeneric:publish -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)
+        env:
+          OSSRH_USERNAME: ${{secrets.OSSRH_USERNAME}}
+          OSSRH_PASSWORD: ${{secrets.OSSRH_PASSWORD}}
+          SONATYPE_STAGING_PROFILE_ID: ${{secrets.SONATYPE_STAGING_PROFILE_ID}}
+          SIGNING_KEY_ID: ${{secrets.SIGNING_KEY_ID}}

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -19,7 +19,6 @@ if (secretPropsFile.exists()) {
     ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
     ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
     ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
-    ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
 }
 
 // Set up Sonatype repository


### PR DESCRIPTION
Add a github action to automatize the publication of the Sonatype nexus staging repository.
The action will trigger when a release or draft of a release is published, or a pre-release is changed to a release.

Note: a manual interaction is still required to release the package from the staging repository to the public one. This step is deliberately left to an admin user because is not possible to remove a packet published by mistake.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>