### PR TITLE
Add Document publication workflow

### DIFF
--- a/.github/workflows/doc-workflow.yaml
+++ b/.github/workflows/doc-workflow.yaml
@@ -1,0 +1,46 @@
+name: Docs generation for Github Pages
+
+on:
+  push:
+    branches:
+    - 'master'
+    - 'release-*'
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the source
+      - uses: actions/checkout@v2
+        with:
+          path: astarte-device-sdk-java
+      # Checkout the docs repository
+      - uses: actions/checkout@v2
+        with:
+          repository: astarte-platform/docs
+          ssh-key: ${{ secrets.DOCS_DEPLOY_KEY }}
+          path: docs
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Generate Javadocs with Gradle
+        working-directory: ./astarte-device-sdk-java
+        run: ./gradlew aggregateJavadocs
+      - name: Copy Docs
+        run: |
+          export DOCS_DIRNAME="$(echo ${{ github.ref }} | sed 's,refs/heads/,,' | sed 's/master/snapshot/g' | sed 's/release-//g')/device-sdks/java"
+          rm -rf docs/$DOCS_DIRNAME
+          mkdir -p docs/$DOCS_DIRNAME
+          cp -r astarte-device-sdk-java/build/docs/javadoc/* docs/$DOCS_DIRNAME/
+      - name: Commit files
+        working-directory: ./docs
+        run: |
+          git config --local user.email "astarte-machine@ispirata.com"
+          git config --local user.name "Astarte Bot"
+          git add .
+          git commit -m "Update Java SDK documentation"
+      - name: Push changes
+        working-directory: ./docs
+        run: |
+          git push origin master

--- a/build.gradle
+++ b/build.gradle
@@ -33,3 +33,4 @@ spotless {
 }
 
 apply from: "${rootDir}/scripts/publish-root.gradle"
+apply from: "${rootDir}/scripts/aggregate-javadoc-plugin.gradle"

--- a/examples/Android/build.gradle
+++ b/examples/Android/build.gradle
@@ -35,3 +35,5 @@ dependencies {
 	androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 	androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }
+
+tasks.withType(Javadoc).all { enabled = false }

--- a/examples/Generic/build.gradle
+++ b/examples/Generic/build.gradle
@@ -11,3 +11,5 @@ dependencies {
 application {
 	mainClassName = 'org.astarteplatform.devicesdk.generic.examples.ExampleDevice'
 }
+
+tasks.withType(Javadoc).all { enabled = false }

--- a/scripts/aggregate-javadoc-plugin.gradle
+++ b/scripts/aggregate-javadoc-plugin.gradle
@@ -1,0 +1,37 @@
+// Adapted from https://github.com/nebula-plugins/gradle-aggregate-javadocs-plugin to add Android support
+
+class AggregateJavadocPlugin implements Plugin<Project> {
+    static final String AGGREGATE_JAVADOCS_TASK_NAME = 'aggregateJavadocs'
+
+    @Override
+    void apply(Project project) {
+        Project rootProject = project.rootProject
+        rootProject.gradle.projectsEvaluated {
+            Set<Project> javaSubprojects = getJavaSubprojects(rootProject)
+            Set<Project> androidSubprojects = getAndroidSubprojects(rootProject)
+            Set<Project> allSubprojects = javaSubprojects + androidSubprojects
+            if (!allSubprojects.isEmpty()) {
+                rootProject.task(AGGREGATE_JAVADOCS_TASK_NAME, type: Javadoc) {
+                    description = 'Aggregates Javadoc API documentation of all subprojects.'
+                    group = JavaBasePlugin.DOCUMENTATION_GROUP
+                    dependsOn allSubprojects.javadoc
+
+                    source allSubprojects.javadoc.source
+                    destinationDir rootProject.file("$rootProject.buildDir/docs/javadoc")
+                    classpath = rootProject.files(javaSubprojects.javadoc.classpath)
+                    title = "Astarte Device SDK Java"
+                }
+            }
+        }
+    }
+
+    private static Set<Project> getJavaSubprojects(Project rootProject) {
+        rootProject.subprojects.findAll { subproject -> subproject.plugins.hasPlugin(JavaPlugin) && subproject.javadoc.isEnabled()}
+    }
+
+    private static Set<Project> getAndroidSubprojects(Project rootProject) {
+        rootProject.subprojects.findAll { subproject -> subproject.plugins.findPlugin("com.android.library") && subproject.javadoc.isEnabled()}
+    }
+}
+
+apply plugin: AggregateJavadocPlugin


### PR DESCRIPTION
- Add a Gradle task to aggregate all the various projects javadocs in a single documentation. The Gradle task was adapted from Netflix Nebula `gradle-aggregated-javadocs` to add support to Android projects.
- Add a documentation workflow for GitHub actions to automatize the publication of javadocs.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>