### PR TITLE
Handle the sessionPresent flag from the broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add check that prevents sending an interface with both major and minor version set to 0
 - Add capability to dynamically update the introspection
+- Add handle for the sessionPresent flag from the broker
 
 ## [1.0.3] - 2022-07-05
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/MutualSSLAuthenticationMqttConnectionInfo.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/MutualSSLAuthenticationMqttConnectionInfo.java
@@ -18,6 +18,7 @@ public class MutualSSLAuthenticationMqttConnectionInfo implements MqttConnection
     m_mqttConnectOptions.setMaxInflight(128);
     // We handle this at a different level.
     m_mqttConnectOptions.setAutomaticReconnect(false);
+    m_mqttConnectOptions.setCleanSession(false);
     try {
       m_mqttConnectOptions.setSocketFactory(sslSocketFactory);
     } catch (Exception e) {


### PR DESCRIPTION
It looked like the SDK sent the introspection and all properties every time the device connected even if it was a temporary disconnection. The right behavior should be that those data should be sent only on the first connection or if [the session was cleaned by the broker because considered invalid](https://docs.astarte-platform.org/latest/080-mqtt-v1-protocol.html#session-present).
That anomaly was generated by the MQTT Client library cleaned the session by default for each connection.
This commit deactivates that default behavior.

Close #65 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>