### PR TITLE
Avoid sending unchanged properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add check that prevents sending an interface with both major and minor version set to 0
 - Add capability to dynamically update the introspection
 - Add handle for the sessionPresent flag from the broker
+- Add check that prevents sending unchanged properties.
 
 ## [1.0.3] - 2022-07-05
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePropertyStorage.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePropertyStorage.java
@@ -11,6 +11,9 @@ public interface AstartePropertyStorage {
   List<String> getStoredPathsForInterface(String interfaceName)
       throws AstartePropertyStorageException;
 
+  Object getStoredValue(AstarteInterface astarteInterface, String path)
+      throws AstartePropertyStorageException;
+
   void setStoredValue(String interfaceName, String path, Object value)
       throws AstartePropertyStorageException;
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDevicePropertyInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDevicePropertyInterface.java
@@ -22,7 +22,21 @@ public class AstarteDevicePropertyInterface extends AstartePropertyInterface
       throw new AstarteTransportException("No available transport");
     }
 
-    transport.sendIndividualValue(this, path, payload);
+    Object storedValue = null;
+
+    if (mPropertyStorage != null) {
+      try {
+        storedValue = mPropertyStorage.getStoredValue(this, path);
+      } catch (AstartePropertyStorageException e) {
+        e.printStackTrace();
+      }
+    }
+
+    // If the property changed send it
+    if (!payload.equals(storedValue)) {
+      transport.sendIndividualValue(this, path, payload);
+    }
+
     // Store it
     if (mPropertyStorage != null) {
       try {

--- a/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidPropertyStorage.java
+++ b/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidPropertyStorage.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.astarteplatform.devicesdk.AstartePropertyStorage;
+import org.astarteplatform.devicesdk.AstartePropertyStorageException;
 import org.astarteplatform.devicesdk.protocol.AstarteInterface;
 import org.astarteplatform.devicesdk.protocol.AstarteInterfaceMapping;
 import org.joda.time.DateTime;
@@ -36,6 +37,19 @@ class AstarteAndroidPropertyStorage implements AstartePropertyStorage {
 
       return returnedPaths;
     }
+  }
+
+  @Override
+  public Object getStoredValue(AstarteInterface astarteInterface, String path)
+      throws AstartePropertyStorageException {
+    Map<String, Object> storedValues = getStoredValuesForInterface(astarteInterface);
+    for (Map.Entry<String, Object> entry : storedValues.entrySet()) {
+      if (!AstarteInterface.isPathCompatibleWithMapping(entry.getKey(), path)) {
+        continue;
+      }
+      return entry.getValue();
+    }
+    return null;
   }
 
   @Override

--- a/DeviceSDKGeneric/src/main/java/org/astarteplatform/devicesdk/generic/AstarteGenericPropertyStorage.java
+++ b/DeviceSDKGeneric/src/main/java/org/astarteplatform/devicesdk/generic/AstarteGenericPropertyStorage.java
@@ -58,6 +58,32 @@ class AstarteGenericPropertyStorage implements AstartePropertyStorage {
   }
 
   @Override
+  public Object getStoredValue(AstarteInterface astarteInterface, String path)
+      throws AstartePropertyStorageException {
+    QueryBuilder<AstarteGenericPropertyEntry, String> statementBuilder =
+        mPropertyEntryDao.queryBuilder();
+    synchronized (this) {
+      try {
+        statementBuilder
+            .where()
+            .eq(
+                AstarteGenericPropertyEntry.INTERFACE_FIELD_NAME,
+                astarteInterface.getInterfaceName())
+            .and()
+            .like("path", "%" + path);
+        List<AstarteGenericPropertyEntry> result =
+            mPropertyEntryDao.query(statementBuilder.prepare());
+        if (result.size() == 1) {
+          return deserialize(result.get(0).getBSONValue(), mBSONCallback, mBSONDecoder);
+        }
+        return null;
+      } catch (SQLException e) {
+        throw new AstartePropertyStorageException("Failed to retrieve stored values", e);
+      }
+    }
+  }
+
+  @Override
   public Map<String, Object> getStoredValuesForInterface(AstarteInterface astarteInterface)
       throws AstartePropertyStorageException {
     Map<String, Object> returnedValues = new HashMap<>();


### PR DESCRIPTION
Add a function that retrieves the last data sent on a specific path of an interface. That function is then used to prevent sending properties with unchanged value.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>