### PR TITLE
Avoid adding invalid interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - Unreleased
+### Added
+- Add check that prevents sending an interface with both major and minor version set to 0
+
 ## [1.0.3] - 2022-07-05
 
 ## [1.0.2] - 2022-04-14

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteInterface.java
@@ -86,6 +86,14 @@ public abstract class AstarteInterface {
     astarteInterface.majorVersion = astarteInterfaceObject.getInt("version_major");
     astarteInterface.minorVersion = astarteInterfaceObject.getInt("version_minor");
 
+    if (astarteInterface.majorVersion == 0 && astarteInterface.minorVersion == 0) {
+      // Invalid Major and Minor
+      throw new AstarteInvalidInterfaceException(
+          String.format(
+              "Both Major and Minor version are 0 on interface %s",
+              astarteInterface.getInterfaceName()));
+    }
+
     // Get and create mappings
     astarteInterface.mappings = new HashMap<>();
     JSONArray jsonMappings = astarteInterfaceObject.getJSONArray("mappings");

--- a/DeviceSDK/src/test/java/org/astarteplatform/devicesdk/protocol/AstarteInterfaceTest.java
+++ b/DeviceSDK/src/test/java/org/astarteplatform/devicesdk/protocol/AstarteInterfaceTest.java
@@ -1,0 +1,60 @@
+package org.astarteplatform.devicesdk.protocol;
+
+import static org.junit.Assert.assertEquals;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class AstarteInterfaceTest {
+  @Test
+  public void testSuccessfulFromJson() throws AstarteInvalidInterfaceException {
+    String iface =
+        "{\n"
+            + "    \"interface_name\": \"org.astarte-platform.genericsensors.AvailableSensors\",\n"
+            + "    \"version_major\": 0,\n"
+            + "    \"version_minor\": 1,\n"
+            + "    \"type\": \"properties\",\n"
+            + "    \"ownership\": \"device\",\n"
+            + "    \"description\": \"Describes available generic sensors.\",\n"
+            + "    \"doc\": \"This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.\",\n"
+            + "    \"mappings\": [\n"
+            + "        {\n"
+            + "            \"endpoint\": \"/%{sensor_id}/name\",\n"
+            + "            \"type\": \"string\",\n"
+            + "            \"description\": \"Sensor name.\",\n"
+            + "            \"doc\": \"An arbitrary sensor name.\"\n"
+            + "        },\n"
+            + "        {\n"
+            + "            \"endpoint\": \"/%{sensor_id}/unit\",\n"
+            + "            \"type\": \"string\",\n"
+            + "            \"description\": \"Sample data measurement unit.\",\n"
+            + "            \"doc\": \"SI unit such as m, kg, K, etc...\"\n"
+            + "        }\n"
+            + "    ]\n"
+            + "}\n";
+    JSONObject obj = new JSONObject(iface);
+    final AstarteInterface astarteInterface = AstarteInterface.fromJSON(obj, null);
+    assertEquals(
+        astarteInterface.getInterfaceName(),
+        "org.astarte-platform.genericsensors.AvailableSensors");
+    assertEquals(astarteInterface.getMajorVersion(), 0);
+    assertEquals(astarteInterface.getMinorVersion(), 1);
+  }
+
+  @Test(expected = AstarteInvalidInterfaceException.class)
+  public void testThroeExceptionFromJson() throws AstarteInvalidInterfaceException {
+    String iface =
+        "{\n"
+            + "    \"interface_name\": \"org.astarte-platform.genericsensors.AvailableSensors\",\n"
+            + "    \"version_major\": 0,\n"
+            + "    \"version_minor\": 0,\n"
+            + "    \"type\": \"properties\",\n"
+            + "    \"ownership\": \"device\",\n"
+            + "    \"description\": \"Describes available generic sensors.\",\n"
+            + "    \"doc\": \"This interface allows to describe available sensors and their attributes such as name and sampled data measurement unit. Sensors are identified by their sensor_id. See also org.astarte-platform.genericsensors.AvailableSensors.\",\n"
+            + "    \"mappings\": []\n"
+            + "}\n";
+    JSONObject obj = new JSONObject(iface);
+    AstarteInterface.fromJSON(obj, null);
+  }
+}


### PR DESCRIPTION
Avoid adding an interface with major and minor version number both at zero adding a check to return a specific error.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>