### PR TITLE
Bump gradle and AndroidPlugin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Sending a non-numeric value on an endpoint with type Double now triggers an exception.
 ### Changed
 - Data is now validated against their exact types.
-- Update Gradle to latest stable 7.2
+- Update Gradle to latest stable 7.6
 - [android] Update Android Gradle plugin and Android target version
 
 ## [1.0.4] - 2022-12-13

--- a/DeviceSDKAndroid/build.gradle
+++ b/DeviceSDKAndroid/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-	compileSdkVersion 31
+	compileSdkVersion 33
 	buildToolsVersion "30.0.3"
 
 	defaultConfig {
 		minSdkVersion 23
-		targetSdkVersion 31
+		targetSdkVersion 33
 		versionCode 1
 		versionName project.version
 
@@ -70,9 +70,22 @@ dependencies {
 
 task javadoc(type: Javadoc) {
 	failOnError false
-	source = android.sourceSets.main.java.sourceFiles
+	group = "Documentation"
+	description = "Generate Javadoc"
+	source = android.sourceSets.main.java.srcDirs
 	classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-	classpath += configurations.compile
+	options.memberLevel = JavadocMemberLevel.PROTECTED
+	options.addStringOption('Xmaxwarns', '1')
+	options.addStringOption('Xmaxerrs', '1')
+	options.links "https://docs.oracle.com/javase/8/docs/api"
+	options.linksOffline "https://developer.android.com/reference",
+			"${android.sdkDirectory}/docs/reference"
+	android.libraryVariants.all { variant ->
+		if (variant.name == 'release') {
+			owner.classpath += variant.javaCompileProvider.get().classpath
+		}
+	}
+	exclude '**/R.html', '**/R.*.html', '**/index.html'
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -5,16 +5,13 @@ buildscript {
 		google()
 		mavenCentral()
 	}
-	dependencies {
-		classpath 'com.android.tools.build:gradle:4.2.0'
-		// NOTE: Do not place your application dependencies here; they belong
-		// in the individual module build.gradle files
-	}
 }
 
 plugins {
 	id 'com.diffplug.spotless' version '5.5.1'
 	id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+	id 'com.android.application' version '4.2.2' apply false
+	id 'com.android.library' version '4.2.2' apply false
 }
 
 allprojects {

--- a/examples/Android/build.gradle
+++ b/examples/Android/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-	compileSdkVersion 31
+	compileSdkVersion 33
 	buildToolsVersion "30.0.3"
 
 	defaultConfig {
 		applicationId "org.astarteplatform.devicesdk.android.examples"
 		minSdkVersion 23
-		targetSdkVersion 31
+		targetSdkVersion 33
 		versionCode 1
 		versionName "1.0"
 
@@ -31,9 +31,9 @@ dependencies {
 	implementation fileTree(dir: "libs", include: ["*.jar"])
 	implementation 'androidx.appcompat:appcompat:1.2.0'
 	implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-	testImplementation 'junit:junit:4.13'
-	androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-	androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+	testImplementation 'junit:junit:4.13.2'
+	androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+	androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 }
 
 tasks.withType(Javadoc).all { enabled = false }

--- a/examples/Android/src/main/AndroidManifest.xml
+++ b/examples/Android/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:theme="@style/AppTheme">
         <activity
                 android:name=".MainActivity"
-                android:exported="false">
+                android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,11 @@
+pluginManagement {
+	repositories {
+		gradlePluginPortal()
+		google()
+		mavenCentral()
+	}
+}
+
 include ':DeviceSDK'
 include ':DeviceSDKAndroid'
 include ':DeviceSDKGeneric'


### PR DESCRIPTION
Improve generation of Android javadoc.
Bump Android compile/target SdkVersion.
BuildToolsVersion `30.0.3` is the latest one compatible with AndroidPlugin `4.2.2` and java `1.8`.