### PR TITLE
Expose path from aggregate datastream event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Expose an interface path from Astarte aggregate datastream event.
+
 ## [1.1.0] - 2023-01-16
 
 ## [1.1.0-alpha.0] - 2022-12-15

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteAggregateDatastreamEvent.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteAggregateDatastreamEvent.java
@@ -7,13 +7,14 @@ public class AstarteAggregateDatastreamEvent extends AstarteGenericAggregateEven
   private final DateTime mTimestamp;
 
   public AstarteAggregateDatastreamEvent(
-      String interfaceName, Map<String, Object> values, DateTime timestamp) {
-    super(interfaceName, values);
+      String interfaceName, Map<String, Object> values, DateTime timestamp, String interfacePath) {
+    super(interfaceName, values, interfacePath);
     mTimestamp = timestamp;
   }
 
-  public AstarteAggregateDatastreamEvent(String interfaceName, Map<String, Object> values) {
-    super(interfaceName, values);
+  public AstarteAggregateDatastreamEvent(
+      String interfaceName, Map<String, Object> values, String interfacePath) {
+    super(interfaceName, values, interfacePath);
     mTimestamp = null;
   }
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteGenericAggregateEvent.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteGenericAggregateEvent.java
@@ -1,17 +1,19 @@
 package org.astarteplatform.devicesdk.protocol;
 
 import java.lang.reflect.Type;
-import java.util.Collection;
 import java.util.Map;
 import org.joda.time.DateTime;
 
 public abstract class AstarteGenericAggregateEvent {
   private final String mInterfaceName;
+  private final String mInterfacePath;
   private final Map<String, Object> mValues;
 
-  AstarteGenericAggregateEvent(String interfaceName, Map<String, Object> values) {
+  AstarteGenericAggregateEvent(
+      String interfaceName, Map<String, Object> values, String interfacePath) {
     mInterfaceName = interfaceName;
     mValues = values;
+    mInterfacePath = interfacePath;
   }
 
   public Type valueType() {
@@ -22,8 +24,8 @@ public abstract class AstarteGenericAggregateEvent {
     return mInterfaceName;
   }
 
-  public Collection<String> getPaths() {
-    return mValues.keySet();
+  public String getPath() {
+    return mInterfacePath;
   }
 
   public boolean hasPath(String path) {

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteServerAggregateDatastreamInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteServerAggregateDatastreamInterface.java
@@ -59,7 +59,10 @@ public class AstarteServerAggregateDatastreamInterface extends AstarteAggregateD
   public void publish(AstarteServerValue payload) {
     AstarteAggregateDatastreamEvent e =
         new AstarteAggregateDatastreamEvent(
-            getInterfaceName(), payload.getMapValue(), payload.getTimestamp());
+            getInterfaceName(),
+            payload.getMapValue(),
+            payload.getTimestamp(),
+            payload.getInterfacePath());
     for (AstarteAggregateDatastreamEventListener listener : mListeners) {
       listener.valueReceived(e);
     }

--- a/DeviceSDK/src/test/java/org/astarteplatform/devicesdk/protocol/AstarteServerAggregateDatastreamInterfaceTest.java
+++ b/DeviceSDK/src/test/java/org/astarteplatform/devicesdk/protocol/AstarteServerAggregateDatastreamInterfaceTest.java
@@ -23,11 +23,11 @@ public class AstarteServerAggregateDatastreamInterfaceTest {
           + "    \"aggregation\": \"object\",\n"
           + "    \"mappings\": [\n"
           + "        {\n"
-          + "            \"endpoint\": \"/test/value\",\n"
+          + "            \"endpoint\": \"/config/%{config_id}/param/%{param_id}/value\",\n"
           + "            \"type\": \"double\",\n"
           + "        },\n"
           + "        {\n"
-          + "            \"endpoint\": \"/test/name\",\n"
+          + "            \"endpoint\": \"/config/%{config_id}/param/%{param_id}/name\",\n"
           + "            \"type\": \"string\",\n"
           + "        }\n"
           + "    ]\n"
@@ -48,10 +48,11 @@ public class AstarteServerAggregateDatastreamInterfaceTest {
     expectedValues.put("value", 10.6);
     expectedValues.put("name", "build");
     AstarteServerValue astarteServerValue =
-        datastreamInterface.build("/test", expectedValues, new DateTime());
+        datastreamInterface.build("/config/1/param/2", expectedValues, new DateTime());
 
     assertNotNull("Astarte server value != NULL", astarteServerValue);
-    assertEquals("Compare interface path", astarteServerValue.getInterfacePath(), "/test");
+    assertEquals(
+        "Compare interface path", astarteServerValue.getInterfacePath(), "/config/1/param/2");
 
     Map<String, Object> rValues = astarteServerValue.getMapValue();
     assertTrue("map value not empty", rValues.size() > 0);
@@ -80,10 +81,11 @@ public class AstarteServerAggregateDatastreamInterfaceTest {
           assertTrue("map value not empty", rValues.size() > 0);
           assertEquals("Compare value endpoint", rValues.get("value"), 10.6);
           assertEquals("Compare name endpoint", rValues.get("name"), "build");
+          assertEquals("Compare path", e.getPath(), "/config/1/param/2");
         };
     datastreamInterface.addListener(listener);
     AstarteServerValue astarteServerValue =
-        datastreamInterface.build("/test", expectedValues, new DateTime());
+        datastreamInterface.build("/config/1/param/2", expectedValues, new DateTime());
 
     datastreamInterface.publish(astarteServerValue);
     datastreamInterface.removeListener(listener);

--- a/examples/Android/src/main/java/org/astarteplatform/devicesdk/android/examples/ExampleGlobalEventListener.java
+++ b/examples/Android/src/main/java/org/astarteplatform/devicesdk/android/examples/ExampleGlobalEventListener.java
@@ -52,6 +52,8 @@ public class ExampleGlobalEventListener extends AstarteGlobalEventListener {
         TAG,
         "Received aggregate datastream value on interface "
             + e.getInterfaceName()
+            + ", path: "
+            + e.getPath()
             + ", values: "
             + e.getValues());
   }

--- a/examples/Generic/src/main/java/org/astarteplatform/devicesdk/generic/examples/ExampleGlobalEventListener.java
+++ b/examples/Generic/src/main/java/org/astarteplatform/devicesdk/generic/examples/ExampleGlobalEventListener.java
@@ -51,6 +51,8 @@ class ExampleGlobalEventListener extends AstarteGlobalEventListener {
     System.out.println(
         "Received aggregate datastream value on interface "
             + e.getInterfaceName()
+            + ", path: "
+            + e.getPath()
             + ", values: "
             + e.getValues());
   }


### PR DESCRIPTION
Expose full interface path from aggregate datastream event to a caller. 
If the object is sent on endpoint `/config/1/param/2` using interface mapping:
``` 
"mappings":
    {
       "endpoint": "/config/%{config_id}/param/%{param_id}/duration",
       "type": "integer",
     }
```
, then the caller can receive the same path using the `getPath()` property of 'AstarteAggregateDatastreamEvent' as shown in the examples.
Closes #82 

