### PR TITLE
Avoid to request a certificate with empty CSR

### DIFF
--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/crypto/AstarteCryptoStore.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/crypto/AstarteCryptoStore.java
@@ -1,6 +1,7 @@
 package org.astarteplatform.devicesdk.crypto;
 
 import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -19,7 +20,9 @@ public interface AstarteCryptoStore {
 
   void setAstarteCertificate(Certificate astarteCertificate);
 
-  String generateCSR(String directoryString) throws IOException, OperatorCreationException;
+  String generateCSR(String directoryString)
+      throws IOException, OperatorCreationException, InvalidAlgorithmParameterException,
+          NoSuchAlgorithmException;
 
   SSLSocketFactory getSSLSocketFactory()
       throws KeyManagementException, NoSuchAlgorithmException, CertificateException,

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/crypto/AstarteCryptoStore.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/crypto/AstarteCryptoStore.java
@@ -5,6 +5,7 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -22,7 +23,7 @@ public interface AstarteCryptoStore {
 
   String generateCSR(String directoryString)
       throws IOException, OperatorCreationException, InvalidAlgorithmParameterException,
-          NoSuchAlgorithmException;
+          NoSuchAlgorithmException, NoSuchProviderException;
 
   SSLSocketFactory getSSLSocketFactory()
       throws KeyManagementException, NoSuchAlgorithmException, CertificateException,

--- a/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidCryptoStore.java
+++ b/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidCryptoStore.java
@@ -4,12 +4,14 @@ import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyManagementException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -99,7 +101,8 @@ class AstarteAndroidCryptoStore implements AstarteCryptoStore {
     }
   }
 
-  private void generateKeyPair() throws Exception {
+  private void generateKeyPair()
+      throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
     // Clear the KeyStore first.
     clearKeyStore();
 
@@ -118,15 +121,12 @@ class AstarteAndroidCryptoStore implements AstarteCryptoStore {
   }
 
   @Override
-  public String generateCSR(String directoryString) throws IOException, OperatorCreationException {
+  public String generateCSR(String directoryString)
+      throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, NoSuchProviderException,
+          OperatorCreationException, IOException {
     if (m_keyPair == null) {
       // Generate the key first.
-      try {
-        generateKeyPair();
-      } catch (Exception e) {
-        e.printStackTrace();
-        return "";
-      }
+      generateKeyPair();
     }
     X500Name subjectName = new X500Name(directoryString);
     JcaPKCS10CertificationRequestBuilder kpGen =

--- a/DeviceSDKGeneric/src/main/java/org/astarteplatform/devicesdk/generic/AstarteGenericCryptoStore.java
+++ b/DeviceSDKGeneric/src/main/java/org/astarteplatform/devicesdk/generic/AstarteGenericCryptoStore.java
@@ -2,6 +2,7 @@ package org.astarteplatform.devicesdk.generic;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyManagementException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -66,7 +67,8 @@ class AstarteGenericCryptoStore implements AstarteCryptoStore {
     m_certificate = astarteCertificate;
   }
 
-  private void generateKeyPair() throws Exception {
+  private void generateKeyPair()
+      throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
     // Clear the KeyStore first.
     clearKeyStore();
 
@@ -77,15 +79,12 @@ class AstarteGenericCryptoStore implements AstarteCryptoStore {
   }
 
   @Override
-  public String generateCSR(String directoryString) throws IOException, OperatorCreationException {
+  public String generateCSR(String directoryString)
+      throws IOException, OperatorCreationException, InvalidAlgorithmParameterException,
+          NoSuchAlgorithmException {
     if (m_keyPair == null) {
       // Generate the key first.
-      try {
-        generateKeyPair();
-      } catch (Exception e) {
-        e.printStackTrace();
-        return "";
-      }
+      generateKeyPair();
     }
     X500Name subjectName = new X500Name(directoryString);
     JcaPKCS10CertificationRequestBuilder kpGen =


### PR DESCRIPTION
Removed the generic exception from the `generateKeyPair` function.
Removed the try/catch block from the generateCSR function because it silently returns an empty string instead of an exception.

Closes #77 