### PR TITLE
Implement java logging API

### DIFF
--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
@@ -188,7 +188,7 @@ public abstract class AstartePairableDevice extends AstarteDevice
       if (mAstarteMessageListener != null) {
         mAstarteMessageListener.onFailure(cause);
       } else {
-        logger.severe(cause.getMessage());
+        logger.severe("Transport Connection Initialization Error: " + cause.getMessage());
       }
 
       // Disconnect and reconnect in a separate thread since we can't call
@@ -205,7 +205,7 @@ public abstract class AstartePairableDevice extends AstarteDevice
                     }
                   } catch (AstarteTransportException e) {
                     // Not much that we can do here, we are reconnecting below
-                    logger.severe(e.getMessage());
+                    logger.severe("Error while disconnecting: " + e.getMessage());
                   }
                   eventuallyReconnect();
                 }
@@ -227,7 +227,7 @@ public abstract class AstartePairableDevice extends AstarteDevice
         } catch (AstartePairingException e) {
           if (!eventuallyReconnect()) {
             mAstarteMessageListener.onFailure(e);
-            logger.severe(e.getMessage());
+            logger.severe("Error while reconnecting: " + e.getMessage());
           }
           return;
         }
@@ -240,7 +240,7 @@ public abstract class AstartePairableDevice extends AstarteDevice
           if (mAstarteMessageListener != null) {
             mAstarteMessageListener.onFailure(e);
           } else {
-            logger.severe(e.getMessage());
+            logger.severe("Error while reconnecting: " + e.getMessage());
           }
         }
       } else {

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
@@ -188,7 +188,7 @@ public abstract class AstartePairableDevice extends AstarteDevice
       if (mAstarteMessageListener != null) {
         mAstarteMessageListener.onFailure(cause);
       } else {
-        cause.printStackTrace();
+        logger.severe(cause.getMessage());
       }
 
       // Disconnect and reconnect in a separate thread since we can't call
@@ -205,7 +205,7 @@ public abstract class AstartePairableDevice extends AstarteDevice
                     }
                   } catch (AstarteTransportException e) {
                     // Not much that we can do here, we are reconnecting below
-                    e.printStackTrace();
+                    logger.severe(e.getMessage());
                   }
                   eventuallyReconnect();
                 }
@@ -227,7 +227,7 @@ public abstract class AstartePairableDevice extends AstarteDevice
         } catch (AstartePairingException e) {
           if (!eventuallyReconnect()) {
             mAstarteMessageListener.onFailure(e);
-            e.printStackTrace();
+            logger.severe(e.getMessage());
           }
           return;
         }
@@ -240,7 +240,7 @@ public abstract class AstartePairableDevice extends AstarteDevice
           if (mAstarteMessageListener != null) {
             mAstarteMessageListener.onFailure(e);
           } else {
-            e.printStackTrace();
+            logger.severe(e.getMessage());
           }
         }
       } else {

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairableDevice.java
@@ -1,11 +1,9 @@
 package org.astarteplatform.devicesdk;
 
+import java.util.logging.Logger;
 import org.astarteplatform.devicesdk.crypto.AstarteCryptoException;
 import org.astarteplatform.devicesdk.crypto.AstarteCryptoStore;
-import org.astarteplatform.devicesdk.protocol.AstarteInterface;
-import org.astarteplatform.devicesdk.protocol.AstarteInterfaceAlreadyPresentException;
-import org.astarteplatform.devicesdk.protocol.AstarteInterfaceNotFoundException;
-import org.astarteplatform.devicesdk.protocol.AstarteInvalidInterfaceException;
+import org.astarteplatform.devicesdk.protocol.*;
 import org.astarteplatform.devicesdk.transport.AstarteFailedMessageStorage;
 import org.astarteplatform.devicesdk.transport.AstarteTransport;
 import org.astarteplatform.devicesdk.transport.AstarteTransportEventListener;
@@ -21,6 +19,7 @@ public abstract class AstartePairableDevice extends AstarteDevice
   private boolean mInitialized;
   private boolean mExplicitDisconnectionRequest;
   private java.util.Timer mReconnectTimer;
+  private static Logger logger = Logger.getLogger(AstartePairableDevice.class.getName());
 
   protected AstartePairableDevice(
       AstartePairingHandler pairingHandler,
@@ -127,7 +126,7 @@ public abstract class AstartePairableDevice extends AstarteDevice
       try {
         mAstarteTransport.connect();
       } catch (AstarteCryptoException e) {
-        System.err.println("Regenerating the cert");
+        logger.info("Regenerating the cert");
         // Generate the certificate and try again
         try {
           mPairingHandler.requestNewCertificate();
@@ -219,7 +218,7 @@ public abstract class AstartePairableDevice extends AstarteDevice
   public void onTransportConnectionError(Throwable cause) {
     synchronized (this) {
       if (cause instanceof AstarteCryptoException) {
-        System.err.println("Regenerating the cert");
+        logger.info("Regenerating the cert");
         // Generate the certificate and try again
         try {
           mPairingHandler.requestNewCertificate();

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairingService.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairingService.java
@@ -9,6 +9,7 @@ import java.security.cert.X509Certificate;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.logging.Logger;
 import okhttp3.*;
 import org.apache.commons.io.IOUtils;
 import org.astarteplatform.devicesdk.crypto.AstarteCryptoStore;
@@ -24,6 +25,7 @@ public final class AstartePairingService {
   private final String m_astarteRealm;
   private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
   private final OkHttpClient m_httpClient;
+  private static Logger logger = Logger.getLogger(AstartePairingService.class.getName());
 
   public AstartePairingService(String pairingUrl, String astarteRealm) {
     m_astarteRealm = astarteRealm;
@@ -131,7 +133,7 @@ public final class AstartePairingService {
     JSONObject transportObjects;
     try (Response response = m_httpClient.newCall(request).execute()) {
       String responseBody = response.body().string();
-      System.out.println(responseBody);
+      logger.info("Status informations for a device :" + responseBody);
       JSONObject responseJson = new JSONObject(responseBody);
       transportObjects = responseJson.getJSONObject("data").getJSONObject("protocols");
     } catch (NullPointerException e) {
@@ -150,7 +152,7 @@ public final class AstartePairingService {
       String key = keys.next();
       AstarteProtocolType protocolType = AstarteProtocolType.fromString(key);
       if (protocolType == null) {
-        System.out.println("Found unsupported protocol " + key);
+        logger.warning("Found unsupported protocol " + key);
         continue;
       }
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairingService.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairingService.java
@@ -166,7 +166,7 @@ public final class AstartePairingService {
                 cryptoStore);
         transports.add(supportedTransport);
       } catch (Exception e) {
-        logger.severe(e.getMessage());
+        logger.severe("Error while creating Astarte transport: " + e.getMessage());
       }
     }
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairingService.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/AstartePairingService.java
@@ -166,7 +166,7 @@ public final class AstartePairingService {
                 cryptoStore);
         transports.add(supportedTransport);
       } catch (Exception e) {
-        e.printStackTrace();
+        logger.severe(e.getMessage());
       }
     }
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/crypto/AstarteSslUtils.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/crypto/AstarteSslUtils.java
@@ -17,7 +17,7 @@ class AstarteSslUtils {
           DatatypeConverter.printBase64Binary(cert.getEncoded()).replaceAll("(.{64})", "$1\n"));
       sw.write("\n-----END CERTIFICATE-----\n");
     } catch (CertificateEncodingException e) {
-      logger.severe(e.getMessage());
+      logger.severe("Error while converting certificate to PEM format: " + e.getMessage());
     }
     return sw.toString();
   }

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/crypto/AstarteSslUtils.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/crypto/AstarteSslUtils.java
@@ -3,9 +3,12 @@ package org.astarteplatform.devicesdk.crypto;
 import java.io.StringWriter;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
+import java.util.logging.Logger;
 import javax.xml.bind.DatatypeConverter;
 
 class AstarteSslUtils {
+  private static Logger logger = Logger.getLogger(AstarteSslUtils.class.getName());
+
   public static String certificateToPEM(Certificate cert) {
     StringWriter sw = new StringWriter();
     try {
@@ -14,7 +17,7 @@ class AstarteSslUtils {
           DatatypeConverter.printBase64Binary(cert.getEncoded()).replaceAll("(.{64})", "$1\n"));
       sw.write("\n-----END CERTIFICATE-----\n");
     } catch (CertificateEncodingException e) {
-      e.printStackTrace();
+      logger.severe(e.getMessage());
     }
     return sw.toString();
   }

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDevicePropertyInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDevicePropertyInterface.java
@@ -1,5 +1,6 @@
 package org.astarteplatform.devicesdk.protocol;
 
+import java.util.logging.Logger;
 import org.astarteplatform.devicesdk.AstartePropertyStorage;
 import org.astarteplatform.devicesdk.AstartePropertyStorageException;
 import org.astarteplatform.devicesdk.transport.AstarteTransport;
@@ -10,6 +11,8 @@ public class AstarteDevicePropertyInterface extends AstartePropertyInterface
   AstarteDevicePropertyInterface(AstartePropertyStorage propertyStorage) {
     super(propertyStorage);
   }
+
+  private static Logger logger = Logger.getLogger(AstarteDevicePropertyInterface.class.getName());
 
   @Override
   public void setProperty(String path, Object payload)
@@ -28,7 +31,7 @@ public class AstarteDevicePropertyInterface extends AstartePropertyInterface
       try {
         storedValue = mPropertyStorage.getStoredValue(this, path);
       } catch (AstartePropertyStorageException e) {
-        e.printStackTrace();
+        logger.severe(e.getMessage());
       }
     }
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDevicePropertyInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteDevicePropertyInterface.java
@@ -31,7 +31,8 @@ public class AstarteDevicePropertyInterface extends AstartePropertyInterface
       try {
         storedValue = mPropertyStorage.getStoredValue(this, path);
       } catch (AstartePropertyStorageException e) {
-        logger.severe(e.getMessage());
+        logger.severe(
+            "Error while retrieving stored value for path: " + path + ". " + e.getMessage());
       }
     }
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteServerDatastreamInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteServerDatastreamInterface.java
@@ -3,11 +3,13 @@ package org.astarteplatform.devicesdk.protocol;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.logging.Logger;
 import org.joda.time.DateTime;
 
 public class AstarteServerDatastreamInterface extends AstarteDatastreamInterface
     implements AstarteServerValueBuilder, AstarteServerValuePublisher {
   private final Collection<AstarteDatastreamEventListener> mListeners;
+  private static Logger logger = Logger.getLogger(AstarteServerDatastreamInterface.class.getName());
 
   AstarteServerDatastreamInterface() {
     mListeners = new HashSet<>();
@@ -51,9 +53,8 @@ public class AstarteServerDatastreamInterface extends AstarteDatastreamInterface
               .build();
     } else {
       // Couldn't find the mapping
-      System.err.printf(
-          "Got an unexpected path %s for interface %s!%n", interfacePath, getInterfaceName());
-
+      logger.severe(
+          "Got an unexpected path '" + interfacePath + "' for interface " + getInterfaceName());
       astarteServerValue = null;
     }
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteServerPropertyInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteServerPropertyInterface.java
@@ -3,7 +3,6 @@ package org.astarteplatform.devicesdk.protocol;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.astarteplatform.devicesdk.AstartePropertyStorage;
 import org.joda.time.DateTime;
@@ -55,10 +54,8 @@ public class AstarteServerPropertyInterface extends AstartePropertyInterface
               .build();
     } else {
       // Couldn't find the mapping
-      logger.log(
-          Level.SEVERE,
-          String.format(
-              "Got an unexpected path %s for interface %s!%n", interfacePath, getInterfaceName()));
+      logger.severe(
+          "Got an unexpected path '" + interfacePath + "' for interface " + getInterfaceName());
       astarteServerValue = null;
     }
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteServerPropertyInterface.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/protocol/AstarteServerPropertyInterface.java
@@ -3,12 +3,15 @@ package org.astarteplatform.devicesdk.protocol;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.astarteplatform.devicesdk.AstartePropertyStorage;
 import org.joda.time.DateTime;
 
 public class AstarteServerPropertyInterface extends AstartePropertyInterface
     implements AstarteServerValueBuilder, AstarteServerValuePublisher {
   private final Collection<AstartePropertyEventListener> mListeners;
+  private static Logger logger = Logger.getLogger(AstarteServerPropertyInterface.class.getName());
 
   AstarteServerPropertyInterface(AstartePropertyStorage propertyStorage) {
     super(propertyStorage);
@@ -52,9 +55,10 @@ public class AstarteServerPropertyInterface extends AstartePropertyInterface
               .build();
     } else {
       // Couldn't find the mapping
-      System.err.printf(
-          "Got an unexpected path %s for interface %s!%n", interfacePath, getInterfaceName());
-
+      logger.log(
+          Level.SEVERE,
+          String.format(
+              "Got an unexpected path %s for interface %s!%n", interfacePath, getInterfaceName()));
       astarteServerValue = null;
     }
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/AstarteTransport.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/AstarteTransport.java
@@ -1,6 +1,7 @@
 package org.astarteplatform.devicesdk.transport;
 
 import java.util.Map;
+import java.util.logging.Logger;
 import org.astarteplatform.devicesdk.AstarteDevice;
 import org.astarteplatform.devicesdk.AstarteMessageListener;
 import org.astarteplatform.devicesdk.AstartePropertyStorage;
@@ -14,6 +15,7 @@ import org.astarteplatform.devicesdk.protocol.AstarteProtocolType;
 public abstract class AstarteTransport implements AstarteProtocol {
   private final AstarteProtocolType m_astarteProtocolType;
   private AstarteDevice mDevice;
+  private static Logger logger = Logger.getLogger(AstarteTransport.class.getName());
   protected boolean m_introspectionSent;
   protected AstartePropertyStorage m_propertyStorage;
   protected AstarteFailedMessageStorage m_failedMessageStorage;
@@ -94,7 +96,7 @@ public abstract class AstarteTransport implements AstarteProtocol {
     if (m_propertyStorage != null) {
       m_propertyStorage.setStoredValue(interfaceName, path, value);
     } else {
-      System.err.println("Property storage invalid! Caching won't work");
+      logger.severe("Property storage invalid! Caching won't work");
     }
   }
 
@@ -103,7 +105,7 @@ public abstract class AstarteTransport implements AstarteProtocol {
     if (m_propertyStorage != null) {
       m_propertyStorage.removeStoredPath(interfaceName, path);
     } else {
-      System.err.println("Property storage invalid! Caching won't work");
+      logger.severe("Property storage invalid! Caching won't work");
     }
   }
 }

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/AstarteTransportFactory.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/AstarteTransportFactory.java
@@ -27,7 +27,7 @@ public class AstarteTransportFactory {
               new MutualSSLAuthenticationMqttConnectionInfo(
                   brokerUrl, astarteRealm, deviceId, cryptoStore.getSSLSocketFactory()));
         } catch (Exception e) {
-          logger.severe(e.getMessage());
+          logger.severe("Error while creating Astarte MQTT V1 Transport: " + e.getMessage());
           return null;
         }
       default:

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/AstarteTransportFactory.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/AstarteTransportFactory.java
@@ -1,5 +1,6 @@
 package org.astarteplatform.devicesdk.transport;
 
+import java.util.logging.Logger;
 import org.astarteplatform.devicesdk.crypto.AstarteCryptoStore;
 import org.astarteplatform.devicesdk.protocol.AstarteProtocolType;
 import org.astarteplatform.devicesdk.transport.mqtt.AstarteMqttV1Transport;
@@ -7,6 +8,8 @@ import org.astarteplatform.devicesdk.transport.mqtt.MutualSSLAuthenticationMqttC
 import org.json.JSONObject;
 
 public class AstarteTransportFactory {
+  private static Logger logger = Logger.getLogger(AstarteTransportFactory.class.getName());
+
   public static AstarteTransport createAstarteTransportFromPairing(
       AstarteProtocolType protocolType,
       String astarteRealm,
@@ -24,7 +27,7 @@ public class AstarteTransportFactory {
               new MutualSSLAuthenticationMqttConnectionInfo(
                   brokerUrl, astarteRealm, deviceId, cryptoStore.getSSLSocketFactory()));
         } catch (Exception e) {
-          e.printStackTrace();
+          logger.severe(e.getMessage());
           return null;
         }
       default:

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttTransport.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttTransport.java
@@ -49,9 +49,9 @@ public abstract class AstarteMqttTransport extends AstarteTransport implements I
           if (listener != null) {
             listener.onFailure(derivedException);
           } else {
-            logger.severe(derivedException.getMessage());
+            logger.severe("Error during transport failure: " + derivedException.getMessage());
           }
-          logger.severe(exception.getMessage());
+          logger.severe("Starting exception: " + exception.getMessage());
         }
       };
 
@@ -73,7 +73,7 @@ public abstract class AstarteMqttTransport extends AstarteTransport implements I
       try {
         m_client.close();
       } catch (Exception e) {
-        logger.severe(e.getMessage());
+        logger.severe("Error while closing the MQTT client: " + e.getMessage());
       }
     }
 
@@ -87,7 +87,7 @@ public abstract class AstarteMqttTransport extends AstarteTransport implements I
     try {
       m_client = new MqttAsyncClient(brokerUrl, m_connectionInfo.getClientId(), null);
     } catch (MqttException e) {
-      logger.severe(e.getMessage());
+      logger.severe("Error while initializing the MQTT client: " + e.getMessage());
     }
     m_client.setCallback(mMqttCallback);
   }
@@ -151,7 +151,7 @@ public abstract class AstarteMqttTransport extends AstarteTransport implements I
     }
 
     if (m_astarteTransportEventListener == null) {
-      logger.severe(failureCause.getMessage());
+      logger.severe("Transport failure cause: " + failureCause.getMessage());
       return;
     }
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttTransport.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttTransport.java
@@ -1,5 +1,6 @@
 package org.astarteplatform.devicesdk.transport.mqtt;
 
+import java.util.logging.Logger;
 import javax.net.ssl.SSLHandshakeException;
 import org.astarteplatform.devicesdk.AstarteMessageListener;
 import org.astarteplatform.devicesdk.crypto.AstarteCryptoException;
@@ -16,6 +17,7 @@ public abstract class AstarteMqttTransport extends AstarteTransport implements I
   protected MqttAsyncClient m_client;
   private final MqttConnectionInfo m_connectionInfo;
   private MqttCallback mMqttCallback;
+  private static Logger logger = Logger.getLogger(AstarteMqttTransport.class.getName());
   private final IMqttActionListener mMqttActionListener =
       new IMqttActionListener() {
         public void onSuccess(IMqttToken asyncActionToken) {
@@ -47,9 +49,9 @@ public abstract class AstarteMqttTransport extends AstarteTransport implements I
           if (listener != null) {
             listener.onFailure(derivedException);
           } else {
-            derivedException.printStackTrace();
+            logger.severe(derivedException.getMessage());
           }
-          exception.printStackTrace();
+          logger.severe(exception.getMessage());
         }
       };
 
@@ -71,7 +73,7 @@ public abstract class AstarteMqttTransport extends AstarteTransport implements I
       try {
         m_client.close();
       } catch (Exception e) {
-        e.printStackTrace();
+        logger.severe(e.getMessage());
       }
     }
 
@@ -85,7 +87,7 @@ public abstract class AstarteMqttTransport extends AstarteTransport implements I
     try {
       m_client = new MqttAsyncClient(brokerUrl, m_connectionInfo.getClientId(), null);
     } catch (MqttException e) {
-      e.printStackTrace();
+      logger.severe(e.getMessage());
     }
     m_client.setCallback(mMqttCallback);
   }
@@ -149,7 +151,7 @@ public abstract class AstarteMqttTransport extends AstarteTransport implements I
     }
 
     if (m_astarteTransportEventListener == null) {
-      failureCause.printStackTrace();
+      logger.severe(failureCause.getMessage());
       return;
     }
 

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1Transport.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1Transport.java
@@ -399,7 +399,7 @@ public class AstarteMqttV1Transport extends AstarteMqttTransport implements Mqtt
         }
       }
     } catch (MqttException e) {
-      logger.severe(e.getMessage());
+      logger.severe("Error while setting up subscriptions: " + e.getMessage());
     }
   }
 
@@ -419,7 +419,7 @@ public class AstarteMqttV1Transport extends AstarteMqttTransport implements Mqtt
         result.append(new String(Arrays.copyOf(buf, rlen)));
       }
     } catch (IOException e) {
-      logger.severe(e.getMessage());
+      logger.severe("Error while handling purge properties: " + e.getMessage());
     }
 
     String purgePropertiesPayload = result.toString();

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1Transport.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1Transport.java
@@ -5,6 +5,7 @@ import static org.eclipse.paho.client.mqttv3.MqttException.*;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Logger;
 import java.util.zip.InflaterInputStream;
 import org.astarteplatform.devicesdk.AstartePropertyStorageException;
 import org.astarteplatform.devicesdk.protocol.*;
@@ -24,13 +25,14 @@ public class AstarteMqttV1Transport extends AstarteMqttTransport implements Mqtt
   private final String m_baseTopic;
   private final BSONDecoder mBSONDecoder = new BasicBSONDecoder();
   private final BSONCallback mBSONCallback = new BasicBSONCallback();
+  private static Logger logger = Logger.getLogger(AstarteMqttV1Transport.class.getName());
 
   @Override
   public void connectComplete(boolean reconnect, String serverURI) {
     if (reconnect) {
-      System.out.println("Reconnected to : " + serverURI);
+      logger.info("Reconnected to : " + serverURI);
     } else {
-      System.out.println("Connected to: " + serverURI);
+      logger.info("Connected to : " + serverURI);
     }
   }
 
@@ -39,13 +41,13 @@ public class AstarteMqttV1Transport extends AstarteMqttTransport implements Mqtt
     if (m_astarteTransportEventListener != null) {
       m_astarteTransportEventListener.onTransportDisconnected();
     } else {
-      System.out.println("The Connection was lost.");
+      logger.info("The Connection was lost.");
     }
   }
 
   @Override
   public void messageArrived(String topic, MqttMessage message) throws AstarteTransportException {
-    System.out.println("Incoming message: " + new String(message.getPayload()));
+    logger.info("Incoming message: " + new String(message.getPayload()));
     if (!topic.contains(m_baseTopic) || m_messageListener == null) {
       return;
     }
@@ -57,7 +59,7 @@ public class AstarteMqttV1Transport extends AstarteMqttTransport implements Mqtt
       if (Objects.equals(path, "control/consumer/properties")) {
         handlePurgeProperties(message.getPayload());
       } else {
-        System.err.println("Unhandled control message!" + path);
+        logger.warning("Unhandled control message!" + path);
       }
       return;
     }
@@ -67,7 +69,7 @@ public class AstarteMqttV1Transport extends AstarteMqttTransport implements Mqtt
 
     // Identify in our introspection whether the interface exists
     if (!getDevice().hasInterface(astarteInterface)) {
-      System.err.println("Got an unexpected interface! " + astarteInterface);
+      logger.warning("Got an unexpected interface! " + astarteInterface);
       return;
     }
 
@@ -105,7 +107,7 @@ public class AstarteMqttV1Transport extends AstarteMqttTransport implements Mqtt
           removePropertyFromStorage(astarteInterface, interfacePath);
         }
       } catch (AstartePropertyStorageException e) {
-        System.err.println("AstartePropertyStorageException: Caching won't work " + e.getMessage());
+        logger.severe("Caching won't work " + e.getMessage());
       }
     }
 
@@ -484,7 +486,7 @@ public class AstarteMqttV1Transport extends AstarteMqttTransport implements Mqtt
     if (m_astarteTransportEventListener != null) {
       m_astarteTransportEventListener.onTransportConnected();
     } else {
-      System.out.println("Transport Connected");
+      logger.info("Transport Connected");
     }
   }
 }

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1Transport.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/AstarteMqttV1Transport.java
@@ -399,7 +399,7 @@ public class AstarteMqttV1Transport extends AstarteMqttTransport implements Mqtt
         }
       }
     } catch (MqttException e) {
-      e.printStackTrace();
+      logger.severe(e.getMessage());
     }
   }
 
@@ -419,7 +419,7 @@ public class AstarteMqttV1Transport extends AstarteMqttTransport implements Mqtt
         result.append(new String(Arrays.copyOf(buf, rlen)));
       }
     } catch (IOException e) {
-      e.printStackTrace();
+      logger.severe(e.getMessage());
     }
 
     String purgePropertiesPayload = result.toString();

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/MutualSSLAuthenticationMqttConnectionInfo.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/MutualSSLAuthenticationMqttConnectionInfo.java
@@ -25,7 +25,7 @@ public class MutualSSLAuthenticationMqttConnectionInfo implements MqttConnection
     try {
       m_mqttConnectOptions.setSocketFactory(sslSocketFactory);
     } catch (Exception e) {
-      logger.severe(e.getMessage());
+      logger.severe("Error while setting socket factory: " + e.getMessage());
     }
     m_clientId = astarteRealm + "/" + deviceId;
   }

--- a/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/MutualSSLAuthenticationMqttConnectionInfo.java
+++ b/DeviceSDK/src/main/java/org/astarteplatform/devicesdk/transport/mqtt/MutualSSLAuthenticationMqttConnectionInfo.java
@@ -1,5 +1,6 @@
 package org.astarteplatform.devicesdk.transport.mqtt;
 
+import java.util.logging.Logger;
 import javax.net.ssl.SSLSocketFactory;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 
@@ -7,6 +8,8 @@ public class MutualSSLAuthenticationMqttConnectionInfo implements MqttConnection
   private final String m_brokerUrl;
   private final MqttConnectOptions m_mqttConnectOptions;
   private final String m_clientId;
+  private static Logger logger =
+      Logger.getLogger(MutualSSLAuthenticationMqttConnectionInfo.class.getName());
 
   public MutualSSLAuthenticationMqttConnectionInfo(
       String brokerUrl, String astarteRealm, String deviceId, SSLSocketFactory sslSocketFactory) {
@@ -22,7 +25,7 @@ public class MutualSSLAuthenticationMqttConnectionInfo implements MqttConnection
     try {
       m_mqttConnectOptions.setSocketFactory(sslSocketFactory);
     } catch (Exception e) {
-      e.printStackTrace();
+      logger.severe(e.getMessage());
     }
     m_clientId = astarteRealm + "/" + deviceId;
   }

--- a/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidCryptoStore.java
+++ b/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidCryptoStore.java
@@ -41,22 +41,22 @@ class AstarteAndroidCryptoStore implements AstarteCryptoStore {
       KeyStore.Entry trustedEntry = ks.getEntry("AstarteTrustedCertificate", null);
 
       if (entry == null) {
-        Log.w(TAG, "No key pair found!");
+        Log.w(TAG, "No key pair found in Android Keystore!");
         return;
       }
 
       if (trustedEntry instanceof KeyStore.TrustedCertificateEntry) {
-        Log.i(TAG, "Found a valid, trusted Certificate for Astarte");
+        Log.i(TAG, "Found a valid, trusted Certificate for Astarte in Android Keystore");
         m_certificate = ((KeyStore.TrustedCertificateEntry) trustedEntry).getTrustedCertificate();
-        Log.i(TAG, "Certificate successfully loaded!");
+        Log.i(TAG, "Certificate successfully loaded from Android Keystore!");
       } else if (entry instanceof KeyStore.PrivateKeyEntry) {
         m_publicKey = ((KeyStore.PrivateKeyEntry) entry).getCertificate().getPublicKey();
-        Log.i(TAG, "Found the base Keypair.");
+        Log.i(TAG, "Found the base Keypair in Android Keystore.");
       }
     } catch (KeyStoreException e) {
-      Log.e(TAG, "Could not load keystore! KeyStoreException: " + e);
+      Log.e(TAG, "Error while accessing Android Keystore: ", e);
     } catch (Exception e) {
-      Log.e(TAG, "Could not load keystore! KeyStoreException: " + e);
+      Log.e(TAG, "Error while loading the certificate or key: ", e);
     }
   }
 
@@ -69,7 +69,7 @@ class AstarteAndroidCryptoStore implements AstarteCryptoStore {
       ks.deleteEntry("AstarteCertificate");
       ks.deleteEntry("AstarteTrustedCertificate");
     } catch (Exception e) {
-      Log.e(TAG,e.getMessage());
+      Log.e(TAG, e.getMessage());
     }
   }
 
@@ -94,7 +94,7 @@ class AstarteAndroidCryptoStore implements AstarteCryptoStore {
       ks.setEntry("AstarteTrustedCertificate", entry, null);
     } catch (KeyStoreException e) {
       e.printStackTrace();
-      Log.e(TAG, "Could not load keystore! KeyStoreException: " + e);
+      Log.e(TAG, "Could not load keystore! KeyStoreException: ", e);
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidCryptoStore.java
+++ b/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidCryptoStore.java
@@ -2,6 +2,7 @@ package org.astarteplatform.devicesdk.android;
 
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
+import android.util.Log;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.security.KeyManagementException;
@@ -27,6 +28,7 @@ class AstarteAndroidCryptoStore implements AstarteCryptoStore {
   private PublicKey m_publicKey;
   private KeyPair m_keyPair = null;
   private Certificate m_certificate;
+  private static final String TAG = "AndroidCryptoStore";
 
   public AstarteAndroidCryptoStore() {
     // See if we have something in our Android Keystore already
@@ -39,23 +41,22 @@ class AstarteAndroidCryptoStore implements AstarteCryptoStore {
       KeyStore.Entry trustedEntry = ks.getEntry("AstarteTrustedCertificate", null);
 
       if (entry == null) {
-        System.out.println("No key pair found!");
+        Log.w(TAG, "No key pair found!");
         return;
       }
 
       if (trustedEntry instanceof KeyStore.TrustedCertificateEntry) {
-        System.out.println("Found a valid, trusted Certificate for Astarte");
+        Log.i(TAG, "Found a valid, trusted Certificate for Astarte");
         m_certificate = ((KeyStore.TrustedCertificateEntry) trustedEntry).getTrustedCertificate();
-        System.out.println("Certificate successfully loaded!");
+        Log.i(TAG, "Certificate successfully loaded!");
       } else if (entry instanceof KeyStore.PrivateKeyEntry) {
         m_publicKey = ((KeyStore.PrivateKeyEntry) entry).getCertificate().getPublicKey();
-        System.out.println("Found the base Keypair.");
+        Log.i(TAG, "Found the base Keypair.");
       }
     } catch (KeyStoreException e) {
-      e.printStackTrace();
-      System.err.println("Could not load keystore!");
+      Log.e(TAG, "Could not load keystore! KeyStoreException: " + e);
     } catch (Exception e) {
-      e.printStackTrace();
+      Log.e(TAG, "Could not load keystore! KeyStoreException: " + e);
     }
   }
 
@@ -93,7 +94,7 @@ class AstarteAndroidCryptoStore implements AstarteCryptoStore {
       ks.setEntry("AstarteTrustedCertificate", entry, null);
     } catch (KeyStoreException e) {
       e.printStackTrace();
-      System.err.println("Could not load keystore!");
+      Log.e(TAG, "Could not load keystore! KeyStoreException: " + e);
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidCryptoStore.java
+++ b/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidCryptoStore.java
@@ -69,7 +69,7 @@ class AstarteAndroidCryptoStore implements AstarteCryptoStore {
       ks.deleteEntry("AstarteCertificate");
       ks.deleteEntry("AstarteTrustedCertificate");
     } catch (Exception e) {
-      e.printStackTrace();
+      Log.e(TAG,e.getMessage());
     }
   }
 

--- a/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidMutualSSLSocketFactory.java
+++ b/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidMutualSSLSocketFactory.java
@@ -56,7 +56,7 @@ class AstarteAndroidMutualSSLSocketFactory extends SSLSocketFactory {
                   (X509Certificate) androidKeyStore.getCertificate("AstarteTrustedCertificate");
               return new X509Certificate[] {signedClientCertificate};
             } catch (Exception e) {
-              Log.e(TAG, e.getMessage());
+              Log.e(TAG, "Error while retrieving the certificate chain: ", e);
             }
             return null;
           }
@@ -146,7 +146,7 @@ class AstarteAndroidMutualSSLSocketFactory extends SSLSocketFactory {
     try {
       socket.setReuseAddress(false);
     } catch (Exception e) {
-      Log.e(TAG, e.getMessage());
+      Log.e(TAG, "Error while setting socket reuse address: ", e);
     }
     return socket;
   }

--- a/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidMutualSSLSocketFactory.java
+++ b/DeviceSDKAndroid/src/main/java/org/astarteplatform/devicesdk/android/AstarteAndroidMutualSSLSocketFactory.java
@@ -1,5 +1,6 @@
 package org.astarteplatform.devicesdk.android;
 
+import android.util.Log;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
@@ -20,6 +21,7 @@ import javax.net.ssl.X509ExtendedKeyManager;
 
 class AstarteAndroidMutualSSLSocketFactory extends SSLSocketFactory {
   private SSLSocketFactory internalSSLSocketFactory;
+  private static final String TAG = "AndroidMutSSLSocketFact";
 
   public AstarteAndroidMutualSSLSocketFactory()
       throws KeyManagementException, NoSuchAlgorithmException, CertificateException,
@@ -54,7 +56,7 @@ class AstarteAndroidMutualSSLSocketFactory extends SSLSocketFactory {
                   (X509Certificate) androidKeyStore.getCertificate("AstarteTrustedCertificate");
               return new X509Certificate[] {signedClientCertificate};
             } catch (Exception e) {
-              e.printStackTrace();
+              Log.e(TAG, e.getMessage());
             }
             return null;
           }
@@ -144,7 +146,7 @@ class AstarteAndroidMutualSSLSocketFactory extends SSLSocketFactory {
     try {
       socket.setReuseAddress(false);
     } catch (Exception e) {
-      e.printStackTrace();
+      Log.e(TAG, e.getMessage());
     }
     return socket;
   }

--- a/DeviceSDKGeneric/src/main/java/org/astarteplatform/devicesdk/generic/AstarteGenericMutualSSLSocketFactory.java
+++ b/DeviceSDKGeneric/src/main/java/org/astarteplatform/devicesdk/generic/AstarteGenericMutualSSLSocketFactory.java
@@ -145,7 +145,7 @@ class AstarteGenericMutualSSLSocketFactory extends SSLSocketFactory {
     try {
       socket.setReuseAddress(false);
     } catch (Exception e) {
-      logger.severe(e.getMessage());
+      logger.severe("Error while setting socket reuse address: " + e.getMessage());
     }
     return socket;
   }

--- a/DeviceSDKGeneric/src/main/java/org/astarteplatform/devicesdk/generic/AstarteGenericMutualSSLSocketFactory.java
+++ b/DeviceSDKGeneric/src/main/java/org/astarteplatform/devicesdk/generic/AstarteGenericMutualSSLSocketFactory.java
@@ -15,6 +15,7 @@ import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.logging.Logger;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
@@ -25,6 +26,8 @@ import javax.net.ssl.X509ExtendedKeyManager;
 class AstarteGenericMutualSSLSocketFactory extends SSLSocketFactory {
   private SSLSocketFactory internalSSLSocketFactory;
   private AstarteGenericCryptoStore mCryptoStore;
+  private static Logger logger =
+      Logger.getLogger(AstarteGenericMutualSSLSocketFactory.class.getName());
 
   public AstarteGenericMutualSSLSocketFactory(AstarteGenericCryptoStore cryptoStore)
       throws KeyManagementException, NoSuchAlgorithmException, CertificateException,
@@ -142,7 +145,7 @@ class AstarteGenericMutualSSLSocketFactory extends SSLSocketFactory {
     try {
       socket.setReuseAddress(false);
     } catch (Exception e) {
-      e.printStackTrace();
+      logger.severe(e.getMessage());
     }
     return socket;
   }


### PR DESCRIPTION
Replaced `System.out`, `System.err`, and `e.PrintStackTrace` messages using the Java logging API.
Provided more detailed messages to log.

Closes #78 