### PR TITLE
Add Sonatype publications to CI

### DIFF
--- a/.github/workflows/sonatype-publish.yaml
+++ b/.github/workflows/sonatype-publish.yaml
@@ -1,0 +1,45 @@
+name: Sonatype publication with Gradle
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  sonatype-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      #Run JDK configuration
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      #Gradle cache configuration
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      #Authorizing gradlew files
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      #Build project
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      #Publish project
+      - name: Publish DeviceSDK
+        run: |
+          ./gradlew DeviceSDK:publish
+          ./gradlew DeviceSDKAndroid:publish
+          ./gradlew DeviceSDKGeneric:publish
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -50,9 +50,9 @@ afterEvaluate {
                     }
                     developers {
                         developer {
-                            id = 'rbino'
-                            name = 'Riccardo Binetti'
-                            email = ' riccardo.binetti@ispirata.com'
+                            id = 'harlem88'
+                            name = 'Antonio Gisondi'
+                            email = 'antonio.gisondi@secomind.com'
                         }
                     }
                     scm {
@@ -66,12 +66,13 @@ afterEvaluate {
     }
 }
 
-ext["signing.keyId"] = rootProject.ext["signing.keyId"]
 ext["signing.password"] = rootProject.ext["signing.password"]
-ext["signing.secretKeyRingFile"] = rootProject.ext["signing.secretKeyRingFile"]
+ext["signing.key"] = rootProject.ext["signing.key"]
 
 signing {
-    if( !rootProject.ext["signing.secretKeyRingFile"].toString().isEmpty() ){
-        sign publishing.publications
-    }
+    def signingKey = rootProject.ext["signing.key"].toString()
+    def signingPassword = rootProject.ext["signing.password"].toString()
+
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications
 }

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -2,9 +2,8 @@
 ext["ossrhUsername"] = ''
 ext["ossrhPassword"] = ''
 ext["sonatypeStagingProfileId"] = ''
-ext["signing.keyId"] = ''
 ext["signing.password"] = ''
-ext["signing.secretKeyRingFile"] = ''
+ext["signing.key"] = ''
 
 File secretPropsFile = project.rootProject.file('local.properties')
 if (secretPropsFile.exists()) {
@@ -14,12 +13,11 @@ if (secretPropsFile.exists()) {
     p.each { name, value -> ext[name] = value }
 } else {
     // Use system environment variables
-    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
-    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
-    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
-    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
-    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
-    ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
+    ext["ossrhUsername"] = System.getenv("OSSRH_USERNAME")
+    ext["ossrhPassword"] = System.getenv("OSSRH_PASSWORD")
+    ext["sonatypeStagingProfileId"] = System.getenv("SONATYPE_STAGING_PROFILE_ID")
+    ext["signing.key"] = System.getenv("SIGNING_KEY")
+    ext["signing.password"] = System.getenv("SIGNING_PASSWORD")
 }
 
 // Set up Sonatype repository


### PR DESCRIPTION
Add a github action to automatize the publication of the Sonatype nexus staging repository. The action will trigger when a release or draft of a release is published, or a pre-release is changed to a release.

Note: a manual interaction is still required to release the package from the staging repository to the public one. This step is deliberately left to an admin user because is not possible to remove a packet published by mistake.